### PR TITLE
remove logo that causes CI to blow up

### DIFF
--- a/man/en/cloud-install.1
+++ b/man/en/cloud-install.1
@@ -64,7 +64,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .ft C
 cloud\-install [\-ihf]
 
-Create an Ubuntu Cloud! (requires root privileges)
+Create an Ubuntu Cloud! (requires root privileges)
 
 Options:
   \-i    install only (don\(aqt invoke cloud\-status)


### PR DESCRIPTION
This pull request should cause Travis to run. If Travis works on here better than on master, we should merge this.
