### PR TITLE
Ensure config dir is created for unit test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,12 +62,8 @@ pyflakes:
 pep8:
 	-pep8 cloudinstall
 
-CFGDIR=$(HOME)/.cloud-install
-
-$(CFGDIR):
-	mkdir -p $(CFGDIR)
-
-test: | $(CFGDIR)
+test:
+	mkdir -p $(HOME)/.cloud-install
 	nosetests -v --with-cover --cover-package=cloudinstall --cover-html test
 
 status:


### PR DESCRIPTION
Config dir is created in the cloud-install script, meaning Travis CI doesn't have it when it tries to initialize logging.
