### PR TITLE
Sort charms based on deploy-priority set in charm class. Refactor charm importing.

### DIFF
--- a/cloudinstall/charms/__init__.py
+++ b/cloudinstall/charms/__init__.py
@@ -33,7 +33,7 @@ class CharmBase:
     related = []
     isolate = False
     constraints = None
-    deploy_priority = sys.maxint
+    deploy_priority = sys.maxsize
 
     def __init__(self, state=None, machine=None):
         """ initialize

--- a/cloudinstall/charms/compute.py
+++ b/cloudinstall/charms/compute.py
@@ -37,3 +37,5 @@ class CharmNovaCompute(CharmBase):
                and 'rabbitmq-server' in charm:
                 self.client.add_relation("{c}:amqp".format(c=self.charm_name),
                                          "rabbitmq-server:amqp")
+
+__charm_class__ = CharmNovaCompute

--- a/cloudinstall/charms/controller.py
+++ b/cloudinstall/charms/controller.py
@@ -25,3 +25,5 @@ class CharmNovaCloudController(CharmBase):
     charm_name = 'nova-cloud-controller'
     display_name = 'Nova Cloud Controller'
     related = ['mysql', 'rabbitmq-server', 'glance', 'keystone']
+
+__charm_class__ = CharmNovaCloudController

--- a/cloudinstall/charms/glance.py
+++ b/cloudinstall/charms/glance.py
@@ -25,3 +25,5 @@ class CharmGlance(CharmBase):
     charm_name = 'glance'
     display_name = 'Glance'
     related = ['mysql', 'keystone', 'rabbitmq-server']
+
+__charm_class__ = CharmGlance

--- a/cloudinstall/charms/horizon.py
+++ b/cloudinstall/charms/horizon.py
@@ -1,5 +1,5 @@
 #
-# horizin.py - Openstack Dashboard Charm instructions
+# horizon.py - Openstack Dashboard Charm instructions
 #
 # Copyright 2014 Canonical, Ltd.
 #
@@ -25,3 +25,5 @@ class CharmHorizon(CharmBase):
     charm_name = 'openstack-dashboard'
     display_name = 'Openstack Dashboard (Horizon)'
     related = ['keystone']
+
+__charm_class__ = CharmHorizon

--- a/cloudinstall/charms/jujugui.py
+++ b/cloudinstall/charms/jujugui.py
@@ -29,3 +29,5 @@ class CharmJujuGui(CharmBase):
     def post_proc(self):
         self.client.set_config(self.charm_name,
                                {'password': self.openstack_password()})
+
+__charm_class__ = CharmJujuGui

--- a/cloudinstall/charms/keystone.py
+++ b/cloudinstall/charms/keystone.py
@@ -30,3 +30,5 @@ class CharmKeystone(CharmBase):
         self.client.set_config(self.charm_name,
                                {'admin-password': self.openstack_password(),
                                 'admin-user': 'admin'})
+
+__charm_class__ = CharmKeystone

--- a/cloudinstall/charms/mysql.py
+++ b/cloudinstall/charms/mysql.py
@@ -28,3 +28,5 @@ class CharmMysql(CharmBase):
     def post_proc(self):
         self.client.set_config(self.charm_name,
                                {'dataset-size': '512M'})
+
+__charm_class__ = CharmMysql

--- a/cloudinstall/charms/rabbitmq.py
+++ b/cloudinstall/charms/rabbitmq.py
@@ -23,3 +23,5 @@ class CharmRabbitMQ(CharmBase):
 
     charm_name = 'rabbitmq-server'
     display_name = 'RabbitMQ Server'
+
+__charm_class__ = CharmRabbitMQ

--- a/cloudinstall/gui.py
+++ b/cloudinstall/gui.py
@@ -24,6 +24,8 @@ from traceback import format_exc
 import re
 import threading
 import logging
+import importlib
+import pkgutil
 
 from urwid import (AttrWrap, AttrMap, Text, Columns, Overlay, LineBox,
                    ListBox, Filler, Button, BoxAdapter, Frame, WidgetWrap,
@@ -82,8 +84,8 @@ class ControllerOverlay(Overlay):
         self.command_runner = command_runner
         self.done = False
         self.machine = None
-        self.deployed_charms = []
-        self.finalized_charms = []
+        self.deployed_charm_classes = []
+        self.finalized_charm_classes = []
         self.single_net_configured = False
         self.info_text = Text(self.NODE_WAIT
                               if pegasus.SINGLE_SYSTEM
@@ -112,10 +114,12 @@ class ControllerOverlay(Overlay):
 
     def _process(self, data):
         import cloudinstall.charms
-        helper = utils.ImporterHelper(cloudinstall.charms)
-        charms = helper.get_modules()
 
-        charms = sorted(charms, key=attrgetter('deploy_priority'))
+        charm_modules = [importlib.import_module('cloudinstall.charms.' + mname)
+                         for (_, mname, _) in 
+                         pkgutil.iter_modules(cloudinstall.charms.__path__)]
+        charm_classes = sorted([m.__charm_class__ for m in charm_modules], 
+                               key=attrgetter('deploy_priority'))
 
         if self.machine is None:
             self.machine = self.get_controller_machine(data)
@@ -129,55 +133,54 @@ class ControllerOverlay(Overlay):
             log.debug("starting install on machine {mid}".format(mid=self.machine.machine_id))
 
 
-        undeployed_charms = [c for c in charms if c not in self.deployed_charms]
+        undeployed_charm_classes = [c for c in charm_classes 
+                                    if c not in self.deployed_charm_classes]
 
-        if len(undeployed_charms) > 0:
+        if len(undeployed_charm_classes) > 0:
             self.info_text.set_text("Deploying charms")
             log.debug("Deploying charms")
-            for charm in undeployed_charms:
-                charm_ = utils.import_module('cloudinstall.charms.{charm}'.format(charm=charm))[0]
-                charm_ = charm_(state=data)
+            for charm_class in undeployed_charm_classes:
+                charm = charm_class(state=data)
                 log.debug("checking if {c} is already deployed:".format(c=charm))
                 # charm is loaded, decide whether to run it
-                if charm_.name() in [s.service_name for s in data.services]:
+                if charm.name() in [s.service_name for s in data.services]:
                     log.debug("{c} is already deployed, skipping".format(c=charm))
-                    self.deployed_charms.append(charm)
+                    self.deployed_charm_classes.append(charm_class)
                     continue
 
                 log.debug("{c} is NOT already deployed - deploying".format(c=charm))
 
                 # Hardcode lxc on same machine as they are
                 # created on-demand.
-                charm_.setup(_id='lxc:{mid}'.format(mid=self.machine.machine_id))
-                self.deployed_charms.append(charm)
+                charm.setup(_id='lxc:{mid}'.format(mid=self.machine.machine_id))
+                self.deployed_charm_classes.append(charm_class)
 
-        unfinalized_charms = [c for c in self.deployed_charms if c not in self.finalized_charms]
+        unfinalized_charm_classes = [c for c in self.deployed_charm_classes
+                                     if c not in self.finalized_charm_classes]
 
-        if len(unfinalized_charms) > 0:
+        if len(unfinalized_charm_classes) > 0:
             self.info_text.set_text("Setting charm relations")
             log.debug("Setting charm relations")
-            for charm in [c for c in self.deployed_charms if c not in self.finalized_charms]:
+            for charm_class in unfinalized_charm_classes:
 
-                charm_ = utils.import_module('cloudinstall.charms.'
-                                             '{charm}'.format(charm=charm))[0]
-                charm_ = charm_(state=data)
+                charm = charm_class(state=data)
 
-                if data.service(charm_.charm_name) is None:
+                if data.service(charm.charm_name) is None:
                     # Juju doesn't see the service related to this
                     # charm yet, so defer setting its relations.
-                    log.debug("service not up yet for charm {c}".format(c=charm_.charm_name))
+                    log.debug("service not up yet for charm {c}".format(c=charm.charm_name))
                     continue
 
-                log.debug("calling set_relations() for charm {c}".format(c=charm_.charm_name))
-                charm_.set_relations()
-                charm_.post_proc()
-                self.finalized_charms.append(charm)
+                log.debug("calling set_relations() for charm {c}".format(c=charm.charm_name))
+                charm.set_relations()
+                charm.post_proc()
+                self.finalized_charm_classes.append(charm_class)
 
-        log.debug("at end of process(), deployed_charms={d}"
-                  "finalized_charms={f}".format(d=self.deployed_charms,
-                                                f=self.finalized_charms))
+        log.debug("at end of process(), deployed_charm_classes={d}"
+                  "finalized_charm_classes={f}".format(d=self.deployed_charm_classes,
+                                                f=self.finalized_charm_classes))
 
-        if len(self.finalized_charms) == len(charms):
+        if len(self.finalized_charm_classes) == len(charm_classes):
             log.debug("Charm setup done.")
             return False
         else:


### PR DESCRIPTION
The main functional change here is to add the deploy-priority property and to deploy jujugui first.
The other changes are for clarity and to avoid reimplementing parts of the python standard library.
Details below:
- Import charm classes once at top of _process and sort by deploy-priority class variable.
- Use standard python importlib and pkgutil modules to import classes,
  and use explicit **charm_class** variable in charm modules to avoid
  assuming that the first class in the module is the charm.
- Remove now-unused import helper functions in utils.
