### PR TITLE
Add vlan support in juju-bootstrap node

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -58,7 +58,7 @@ Description: Ubuntu Cloud installer
 Package: cloud-install-multi
 Section: admin
 Architecture: any
-Depends: juju-core, lxc, maas, maas-dhcp, maas-dns, ${misc:Depends}
+Depends: juju-core, lxc, vlan, maas, maas-dhcp, maas-dns, ${misc:Depends}
 Description: Ubuntu Cloud installer (multi-system) - dependency package
  Ubuntu Cloud installer is a metal to cloud image that provides an extremely
  simple way to install, deploy and scale an openstack cloud on top of

--- a/share/juju.sh
+++ b/share/juju.sh
@@ -75,6 +75,12 @@ jujuBootstrap()
 {
 	cluster_uuid=$1
 
+	# Juju >= 1.19 supports vlans. Since we're bootstrapping into a container,
+	# when they try to modprobe the vlan module it won't work (viz. LP #1316762)
+	# inside the container, so our solution is to add it outside the container so
+	# that containers can use vlans.
+	modprobe 8021q
+
 	lxc-create -n juju-bootstrap -t ubuntu-cloud -- -r trusty
 	sed -e "s/^lxc.network.link.*$/lxc.network.link = br0/" -i \
 	    /var/lib/lxc/juju-bootstrap/config


### PR DESCRIPTION
This doesn't (shouldn't?) need to be merged until we start using juju >= 1.19 and/or LP 1316762 is fixed.
