### PR TITLE
Add option to not merge stdout and stderr in get_command_output

### DIFF
--- a/cloudinstall/juju/client.py
+++ b/cloudinstall/juju/client.py
@@ -138,7 +138,7 @@ class JujuClient:
             if opts:
                 cmd = "{cmd} --constraints \"{opts}\"".format(cmd=cmd,
                                                           opts=" ".join(opts))
-        ret, out, rtime = get_command_output(cmd)
+        ret, out, _, _ = get_command_output(cmd)
         log.debug("Machine added: {cmd} ({out})".format(cmd=cmd, out=out))
         return out
 
@@ -159,7 +159,7 @@ class JujuClient:
                                                  b=endpoint_b)
         log.debug("Adding relation {a} <-> {b}".format(a=endpoint_a,
                                                        b=endpoint_b))
-        ret, out, _ = get_command_output(cmd)
+        ret, out, _, _ = get_command_output(cmd)
         return out
 
     # def remove_relation(self, endpoint_a, endpoint_b):
@@ -209,7 +209,7 @@ class JujuClient:
                                                           opts=" ".join(opts))
         cmd = "{cmd} {charm}".format(cmd=cmd, charm=charm)
         log.debug("Deploying {charm} -> {cmd}".format(charm=charm, cmd=cmd))
-        ret, out, _ = get_command_output(cmd)
+        ret, out, _, _ = get_command_output(cmd)
         log.debug("Deploy result: {out}".format(out=out))
         if ret:
             log.warning("Deploy error ({cmd}): {out}".format(cmd=cmd,
@@ -233,7 +233,7 @@ class JujuClient:
         for k,v in config_keys.items():
             cmd = "juju set {service} {k}={v}".format(service=service_name,
                                                       k=k, v=v)
-            ret, out, _ = get_command_output(cmd)
+            ret, out, _, _ = get_command_output(cmd)
             if ret:
                 log.warning("Problem setting config: " \
                             "{out}".format(out=out))
@@ -339,7 +339,7 @@ class JujuClient:
             cmd += " -n {count}".format(count=count)
         log.debug("Adding additional {name}, cmd='{cmd}'"
                   .format(name=service_name, cmd=cmd))
-        ret, out, _ = get_command_output(cmd)
+        ret, out, _, _ = get_command_output(cmd)
         if ret:
             log.warning("Problem adding {name} " \
                         "{out}".format(name=service_name,

--- a/cloudinstall/utils.py
+++ b/cloudinstall/utils.py
@@ -46,18 +46,20 @@ def async(func):
     return wrapper
 
 
-def get_command_output(command, timeout=300):
+def get_command_output(command, timeout=300, combine_output=True):
     """ Execute command through system shell
 
     :param command: command to run
+    :param timeout: (optional) use 'timeout' to limit time. default 300
+    :param combine_output: (optional) combine stderr and stdout. default True.
     :type command: str
-    :returns: (returncode, stdout, 0)
+    :returns: (returncode, stdout, stderr, 0)
     :rtype: tuple
 
     .. code::
 
         # Get output of juju status
-        ret, out, rtime = utils.get_command_output('juju status')
+        ret, out, err, rtime = utils.get_command_output('juju status')
     """
     cmd_env = os.environ.copy()
     # set consistent locale
@@ -65,11 +67,18 @@ def get_command_output(command, timeout=300):
     if timeout:
         command = "timeout %ds %s" % (timeout, command)
 
+    if combine_output:
+        stderr_dest=STDOUT
+    else:
+        stderr_dest=PIPE
+
     p = Popen(command, shell=True,
-              stdout=PIPE, stderr=STDOUT,
+              stdout=PIPE, stderr=stderr_dest,
               bufsize=-1, env=cmd_env, close_fds=True)
     stdout, stderr = p.communicate()
-    return (p.returncode, stdout.decode('utf-8'), 0)
+    if stderr:
+        stderr = stderr.decode('utf-8')
+    return (p.returncode, stdout.decode('utf-8'), stderr, 0)
 
 
 def get_network_interface(iface):
@@ -85,7 +94,7 @@ def get_network_interface(iface):
         # Get address, broadcast, and netmask of eth0
         iface = utils.get_network_interface('eth0')
     """
-    (status, output, runtime) = get_command_output('ifconfig %s' % (iface,))
+    status, output, _, _ = get_command_output('ifconfig %s' % (iface,))
     line = output.split('\n')[1:2][0].lstrip()
     regex = re.compile('^inet addr:([0-9]+(?:\.[0-9]+){3})\s+Bcast:([0-9]+(?:\.[0-9]+){3})\s+Mask:([0-9]+(?:\.[0-9]+){3})')
     match = re.match(regex, line)
@@ -102,7 +111,7 @@ def get_network_interfaces():
     :returns: available interfaces and their properties
     :rtype: generator
     """
-    (status, output, runtime) = get_command_output('ifconfig -s')
+    status, output, _, _ = get_command_output('ifconfig -s')
     _ifconfig = output.split('\n')[1:-1]
     for i in _ifconfig:
         name = i.split(' ')[0]
@@ -116,7 +125,7 @@ def get_host_mem():
     Mostly used as a backup if no data can be pulled from
     the normal means in Machine()
     """
-    _, out, _ = get_command_output('head -n1 /proc/meminfo')
+    _, out, _, _ = get_command_output('head -n1 /proc/meminfo')
     out = out.rstrip()
     regex = re.compile('^MemTotal:\s+(\d+)\skB')
     match = re.match(regex, out)
@@ -132,7 +141,7 @@ def get_host_storage():
 
     LXC doesn't report storage so we pull from host
     """
-    ret, out, _ = get_command_output('df -B G --total -l --output=avail -x devtmpfs -x tmpfs | tail -n 1 | tr -d "G"')
+    ret, out, _, _ = get_command_output('df -B G --total -l --output=avail -x devtmpfs -x tmpfs | tail -n 1 | tr -d "G"')
     if not ret:
         return out.lstrip()
     else:
@@ -144,7 +153,7 @@ def get_host_cpu_cores():
     A backup if no data can be pulled from
     Machine()
     """
-    _, out, _ = get_command_output('nproc')
+    _, out, _, _ = get_command_output('nproc')
     if out:
         return out.strip()
     else:


### PR DESCRIPTION
Allows us to avoid trying to parse stderr as YAML.

"juju status" will dump warnings (eg about config file keys it doesn't recognize) to stderr, and trying to parse that along with the stdout yaml will break.

Signed-off-by: Michael McCracken mike.mccracken@canonical.com
