### PR TITLE
Add allow_multi tag to swift charms

### DIFF
--- a/cloudinstall/charms/swift.py
+++ b/cloudinstall/charms/swift.py
@@ -28,6 +28,7 @@ class CharmSwift(CharmBase):
     deploy_priority = 5
     default_replicas = 3
     isolate = True
+    allow_multi_units = True
 
     def setup(self):
         """Custom setup for swift-storage to get replicas from config"""

--- a/cloudinstall/charms/swift_proxy.py
+++ b/cloudinstall/charms/swift_proxy.py
@@ -29,5 +29,6 @@ class CharmSwiftProxy(CharmBase):
     constraints = {'mem': '1G',
                    'root-disk': '8G'}
     isolate = True
+    allow_multi_units = True
 
 __charm_class__ = CharmSwiftProxy


### PR DESCRIPTION
 so we can add units to them using the GUI

Signed-off-by: Michael McCracken mike.mccracken@canonical.com
