### PR TITLE
Make all packages architecture-independent

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -57,7 +57,7 @@ Description: Ubuntu Cloud installer
 
 Package: cloud-install-multi
 Section: admin
-Architecture: any
+Architecture: all
 Depends: juju-core, lxc, maas, maas-dhcp, maas-dns, ${misc:Depends}
 Description: Ubuntu Cloud installer (multi-system) - dependency package
  Ubuntu Cloud installer is a metal to cloud image that provides an extremely
@@ -70,7 +70,7 @@ Description: Ubuntu Cloud installer (multi-system) - dependency package
 
 Package: cloud-install-single
 Section: admin
-Architecture: any
+Architecture: all
 Depends: juju-local, uvtool, uvtool-libvirt, ${misc:Depends}
 Description: Ubuntu Cloud installer (single-system) - dependency package
  Ubuntu Cloud installer is a metal to cloud image that provides an extremely
@@ -83,7 +83,7 @@ Description: Ubuntu Cloud installer (single-system) - dependency package
 
 Package: cloud-install-landscape
 Section: admin
-Architecture: any
+Architecture: all
 Depends: cloud-install-multi, juju-deployer, ${misc:Depends}
 Description: Ubuntu Cloud installer (landscape) - dependency package
  Ubuntu Cloud installer is a metal to cloud image that provides an extremely


### PR DESCRIPTION
cloud-installer's binary packages are identical across architectures except for the Architecture field, so there's no reason for them to be architecture-dependent.

(For somewhat arcane reasons, these packages being "Architecture: any" blocks the promotion of the new version of syslinux to utopic, so I'd appreciate this being uploaded to utopic even if the other changes in master are going to take a while.  This is because installability checks are applied a bit differently for architecture-dependent and architecture-independent packages, and the new version of syslinux restricts syslinux-common to just amd64 and i386, which has some fallout further up the stack; making these binaries Architecture: all works around this, and is the right thing to do anyway.)
