### PR TITLE
Break out loading of charm modules into helper function

### DIFF
--- a/cloudinstall/utils.py
+++ b/cloudinstall/utils.py
@@ -38,19 +38,14 @@ blank_len = None
 
 
 def load_charms():
-    """ Load known charm classes
+    """ Load known charm modules
     """
     import cloudinstall.charms
 
     charm_modules = [import_module('cloudinstall.charms.' + mname)
                      for (_, mname, _) in
                      pkgutil.iter_modules(cloudinstall.charms.__path__)]
-
-    charm_classes = sorted([m.__charm_class__ for m in charm_modules
-                            if not m.__charm_class__.optional and
-                            not m.__charm_class__.disabled],
-                           key=attrgetter('deploy_priority'))
-    return charm_classes
+    return charm_modules
 
 
 def async(func):


### PR DESCRIPTION
This is primarily to cleanup some of the redundant code within the
gui logic. It is my intention to make the loading of charm modules filterable
to further clean up any duplicated code.

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
