### PR TITLE
make swift-proxy rely on glance before relation

### DIFF
--- a/cloudinstall/charms/glance.py
+++ b/cloudinstall/charms/glance.py
@@ -24,6 +24,6 @@ class CharmGlance(CharmBase):
 
     charm_name = 'glance'
     display_name = 'Glance'
-    related = ['mysql', 'keystone', 'rabbitmq-server', 'swift-proxy']
+    related = ['mysql', 'keystone', 'rabbitmq-server']
 
 __charm_class__ = CharmGlance

--- a/cloudinstall/charms/swift_proxy.py
+++ b/cloudinstall/charms/swift_proxy.py
@@ -24,7 +24,7 @@ class CharmSwiftProxy(CharmBase):
 
     charm_name = 'swift-proxy'
     display_name = 'Swift Proxy'
-    related = ['keystone']
+    related = ['keystone', 'glance']
     deploy_priority = 5
     constraints = {'mem': '1G',
                    'root-disk': '8G'}


### PR DESCRIPTION
since glance is one of the core services to always be up and
swift-proxy is optional we make switf-proxy relate to glance
rather than the opposite.

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
