### PR TITLE
increase disk storage for compute node

### DIFF
--- a/cloudinstall/charms/compute.py
+++ b/cloudinstall/charms/compute.py
@@ -27,7 +27,7 @@ class CharmNovaCompute(CharmBase):
     related = ['mysql', 'rabbitmq-server', 'glance', 'nova-cloud-controller']
     isolate = True
     constraints = {'mem': '4G',
-                   'root-disk': '10G'}
+                   'root-disk': '40G'}
     allow_multi_units = True
 
     def set_relations(self):


### PR DESCRIPTION
The current trusty images require at least a m1.small or larger
for a instance deploy will work. So we need to increase our disk storage
in order to meet these requirements.

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
