### PR TITLE
better error handling for additional set relations in compute

### DIFF
--- a/cloudinstall/charms/compute.py
+++ b/cloudinstall/charms/compute.py
@@ -37,9 +37,9 @@ class CharmNovaCompute(CharmBase):
     def set_relations(self):
         super(CharmNovaCompute, self).set_relations()
         juju, _ = poll_state()
-        services = juju.service(self.charm_name)
+        service = juju.service(self.charm_name)
         has_amqp = list(filter(lambda r: 'amqp' in r.relation_name,
-                        services.relations))
+                        service.relations))
         if len(has_amqp) == 0:
             log.debug("Setting amqp relation for compute.")
             ret = self.client.add_relation("{c}:amqp".format(


### PR DESCRIPTION
set_relations() was attempting to relate rabbitmq-server to nova-compute.
There was no interface for that so an exception was being thrown. This
change fixes that exception and provides a more reliable way to relate
rabbitmq-server:amqp to nova-compute:amqp which is the proper requirement
for those services.

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
