### PR TITLE
Add command line flag to enable swift by default

### DIFF
--- a/bin/cloud-install
+++ b/bin/cloud-install
@@ -29,15 +29,17 @@
 OPT_HELP=h
 OPT_INSTALL=i
 OPT_CONFIGFILE=c
-OPTS=:${OPT_CONFIGFILE}:${OPT_INSTALL}${OPT_HELP}
+OPT_ENABLESWIFT=s
+OPTS=:${OPT_CONFIGFILE}:${OPT_INSTALL}${OPT_ENABLESWIFT}${OPT_HELP}
 USAGE="\
-cloud-install [-${OPT_CONFIGFILE}${OPT_INSTALL}${OPT_HELP}]
+cloud-install [-${OPT_CONFIGFILE}${OPT_INSTALL}${OPT_ENABLESWIFT}${OPT_HELP}]
 
 Create an Ubuntu Openstack Cloud! (requires root privileges)
 
 Options:
   -$OPT_CONFIGFILE <file> - POSIX shell script to be sourced by installer
       automating install by pre-setting menu responses.
+  -$OPT_ENABLESWIFT enable swift-storage
   -$OPT_INSTALL  install only (don't invoke cloud-status)
   -$OPT_HELP  print this message"
 
@@ -56,6 +58,9 @@ while getopts $OPTS opt; do
 	case $opt in
 	$OPT_INSTALL)
 		install=true
+		;;
+	$OPT_ENABLESWIFT)
+		enableswift="--enable-swift"
 		;;
 	$OPT_HELP)
 		usage
@@ -123,5 +128,5 @@ else
 fi
 if [ -z "$install" ]; then
 	exitInstall
-	cd "/home/$INSTALL_USER"; exec sudo -H -u "$INSTALL_USER" cloud-status
+	cd "/home/$INSTALL_USER"; exec sudo -H -u "$INSTALL_USER" cloud-status $enableswift
 fi

--- a/bin/cloud-status
+++ b/bin/cloud-status
@@ -20,6 +20,7 @@
 
 import signal
 import sys
+import argparse
 
 from cloudinstall import gui
 from cloudinstall import utils
@@ -32,6 +33,15 @@ def sig_handler(signum, frame):
 for sig in (signal.SIGTERM, signal.SIGQUIT, signal.SIGINT, signal.SIGHUP):
     signal.signal(sig, sig_handler)
 
+def parse_options(*args, **kwds):
+    parser = argparse.ArgumentParser(description='Ubuntu Openstack Installer',
+                                     prog='cloud-status')
+    parser.add_argument('--enable-swift', action='store_true',
+                        dest='enable_swift', default=False,
+                        help='Enable swift storage')
+    return parser.parse_args()
+
 if __name__ == '__main__':
-    gui = gui.PegasusGUI()
+    opts = parse_options(sys.argv)
+    gui = gui.PegasusGUI(opts)
     sys.exit(gui.run())


### PR DESCRIPTION
The cloud-install shell scripts takes '-s' flag in order to enable swift from
installation. However, cloud-status takes '--enable-swift' if cloud-status
is invoked directly. It would be best to keep those flags similar, however,
the shell interpreter is limited w.r.t. getopts parsing.

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
