### PR TITLE
disable swift storage in sync charm by default

### DIFF
--- a/share/juju.sh
+++ b/share/juju.sh
@@ -84,6 +84,8 @@ configCharmOptions()
                   instance-mtu: 1400
                 nova-cloud-controller:
                   network-manager: Neutron
+                glance-simplestreams-sync:
+                  use_swift: False
 		EOF
 }
 


### PR DESCRIPTION
Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
