### PR TITLE
sort started machines list to predictably choose the lowest-numbered one

### DIFF
--- a/cloudinstall/gui.py
+++ b/cloudinstall/gui.py
@@ -374,7 +374,7 @@ class Node(WidgetWrap):
         for u in sorted(service.units, key=attrgetter('unit_name')):
             info = "{unit_name} " \
                    "({status})".format(unit_name=u.unit_name,
-                                         status=u.agent_state)
+                                       status=u.agent_state)
 
             if u.public_address:
                 info += "\naddress: {address}".format(address=u.public_address)


### PR DESCRIPTION
A rare case where more than one machine is started will result in get_started_machine picking an arbitrary one. If pegasus is re-run for any reason, we want it to pick the same one every time if possible.

Sorting the array by machine ID (as int) gives us the same expected behavior every time.
