### PR TITLE
config option is lxc-clone

### DIFF
--- a/share/juju.sh
+++ b/share/juju.sh
@@ -36,7 +36,7 @@ configMaasEnvironment()
 		    default-series: trusty
 		    authorized-keys-path: ~/.ssh/id_rsa.pub
 		    apt-http-proxy: 'http://$1:8000/'
-		    lxc-use-clone: true
+		    lxc-clone: true
 		EOF
 }
 
@@ -55,7 +55,7 @@ configLocalEnvironment()
 		  local:
 		    type: local
 		    container: kvm
-		    lxc-use-clone: true
+		    lxc-clone: true
 		EOF
 }
 


### PR DESCRIPTION
After running the script I tried (and got):

```
$ juju status
WARNING unknown config field "lxc-use-clone"
WARNING unknown config field "lxc-use-clone"
WARNING unknown config field "lxc-use-clone"
```

I believe the actual option is **lxc-clone: true**
