### PR TITLE
Don't require lp:landscape-charm to be in ~

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ debian/cloud-install-single/
 debian/cloud-install-multi/
 debian/cloud-install-landscape/
 *.swp
+# the dependencies deb
+*.deb

--- a/Makefile
+++ b/Makefile
@@ -82,13 +82,16 @@ run: ../cloud-installer*.deb
 	apt-get -yy install -f
 	MAAS_HTTP_PROXY=${proxy} cloud-install
 
-# sudo make landscape proxy=http://localhost:3128/
+# sudo make landscape
 .PHONY: landscape
 landscape: ../cloud-installer*.deb
 	-dpkg -i ../cloud-installer*deb
 	-dpkg -i ../cloud-install-multi*deb
 	-dpkg -i ../cloud-install-landscape*deb
 	apt-get -yy install -f
-	MAAS_HTTP_PROXY=${proxy} cloud-install
+	@echo please follow the instructions in
+	@echo "/usr/share/cloud-installer/templates/landscape-deployments.yaml"
+	@echo and then run `sudo cloud-install` as usual
+
 
 all: deb

--- a/debian/cloud-installer.install
+++ b/debian/cloud-installer.install
@@ -16,4 +16,5 @@ share/templates/bootresources.yaml     usr/share/cloud-installer/templates
 share/templates/lxc-host-only          usr/share/cloud-installer/templates
 share/templates/nova-controller-setup.sh     usr/share/cloud-installer/templates
 share/templates/quantum-network.sh     usr/share/cloud-installer/templates
+share/templates/landscape-deployments.yaml    usr/share/cloud-installer/templates
 tools/cloud-uninstall                  usr/share/cloud-installer/tools

--- a/share/landscape.sh
+++ b/share/landscape.sh
@@ -25,13 +25,9 @@ deployLandscape()
 	end_percent=${1:-100}
 	mkfifo -m 0600 "$TMP/deployer-out"
 
-	# For now, we assume that the install user has the landscape charm with the
-	# right licensing configs cloned into their home directory; we can fix this
-	# later when the landscape charm deploys with a free license.
-	cd "/home/$INSTALL_USER/landscape-charm/config" && \
-	    sudo -H -u "$INSTALL_USER" \
-	    juju-deployer -Wdv -c landscape-deployments.yaml landscape-dense-maas \
-	    > "$TMP/deployer-out" 2>&1 &
+	sudo -H -u "$INSTALL_USER" \
+		juju-deployer -Wdv -c /usr/share/cloud-installer/templates/landscape-deployments.yaml landscape-dense-maas \
+		> "$TMP/deployer-out" 2>&1 &
 
 	lines_seen=0
 	while IFS=: read unused; do

--- a/share/templates/landscape-deployments.yaml
+++ b/share/templates/landscape-deployments.yaml
@@ -1,0 +1,85 @@
+# Copied from lp:landscape-charm /config/landscape-deployments.yaml
+# and then:
+#   # charm no longer requires a license file
+#   sed -e 's/license-file$/\/dev\/null/g' -i landscape-deployments.yaml
+#
+#   Users who want to use the landscape installer should:
+#   # $CONTENTS here is what is in https://pastebin.canonical.com/112787/
+#   # for now. When landscape is released, we can make this something public.
+#   sed -e 's/include-file:\/\/repo-file/$CONTENTS/g' -i landscape-deployments.yaml
+_common:
+    services:
+        rabbitmq-server:
+            charm: cs:precise/rabbitmq-server-27
+        postgresql:
+            charm: cs:precise/postgresql-71
+            constraints: mem=2048
+            options:
+                extra-packages: python-apt postgresql-contrib postgresql-.*-debversion
+                max_connections: 500
+        haproxy:
+            charm: cs:precise/haproxy-31
+            options:
+                enable_monitoring: True
+                monitoring_allowed_cidr: "0.0.0.0/0"
+                monitoring_password: "haproxy"
+                default_timeouts: "queue 60000, connect 5000, client 120000, server 120000"
+                # Don't deploy default haproxy service on port 80
+                services: ""
+        apache2:
+            charm: cs:precise/apache2-21
+            expose: True
+            options:
+                enable_modules: proxy proxy_http proxy_balancer rewrite expires headers ssl
+                ssl_cert: SELFSIGNED
+                ssl_certlocation: apache2.cert
+                ssl_keylocation: apache2.key
+
+landscape:
+    inherits: _common
+    series: precise
+    services:
+        landscape:
+            branch: lp:~landscape/landscape-charm/stable
+            constraints: mem=2048
+            options:
+                service-count: "2"
+                landscape-password: "look-a-different-password"
+                services: static appserver pingserver combo-loader async-frontend apiserver package-upload jobhandler package-search cron juju-sync
+                repository: include-file://repo-file
+                license-file: file:///dev/null
+        landscape-msg:
+            branch: lp:~landscape/landscape-charm/stable
+            charm: landscape
+            constraints: mem=2048
+            options:
+                landscape-password: "look-a-different-password"
+                services: msgserver
+                repository: include-file://repo-file
+                license-file: file:///dev/null
+    relations:
+        - [landscape, rabbitmq-server]
+        - [landscape, haproxy]
+        - ["landscape:vhost-config", "apache2:vhost-config"]
+        - ["landscape:db-admin", "postgresql:db-admin"]
+        - ["haproxy:website", "apache2:reverseproxy"]
+        - [landscape-msg, rabbitmq-server]
+        - [landscape-msg, haproxy]
+        - ["landscape-msg:db-admin", "postgresql:db-admin"]
+
+landscape-dense-maas:
+    inherits: landscape
+    services:
+        landscape:
+            to: lxc:0
+        landscape-msg:
+            to: lxc:0
+        postgresql:
+            to: lxc:0
+        rabbitmq-server:
+            to: lxc:0
+        apache2:
+            to: lxc:0
+        haproxy:
+            to: lxc:0
+


### PR DESCRIPTION
There still isn't a totally unsupervised way to do the landscape install since
they require the private/unreleased PPA. Users need to follow the instructions
at /usr/share/cloud-install/templates/landscape-deployments.yaml (which include
canonical-only accessible parts at this point).
