### PR TITLE
Don't hardcode home directory paths

### DIFF
--- a/share/common.sh
+++ b/share/common.sh
@@ -168,9 +168,9 @@ exitInstall()
 #
 generateSshKeys()
 {
-	if [ ! -e "/home/$INSTALL_USER/.ssh/id_rsa" ]; then
+	if [ ! -e "$INSTALL_HOME/.ssh/id_rsa" ]; then
 	    sudo -u "$INSTALL_USER" ssh-keygen -N "" \
-		 -f "/home/$INSTALL_USER/.ssh/id_rsa" 1>&2
+		 -f "$INSTALL_HOME/.ssh/id_rsa" 1>&2
 	else
 	    echo "*** ssh keys exist for this user, they will be used instead."
 	    echo "*** If the current ssh keys are not passwordless you'll be"
@@ -294,6 +294,7 @@ ts()
 }
 
 INSTALL_USER=${SUDO_USER:-root}
+INSTALL_HOME=$(getent passwd $INSTALL_USER | cut -d: -f6)
 
 # HELPER TOOLS
 configure_landscape=/usr/share/cloud-installer/bin/configure-landscape

--- a/share/juju.sh
+++ b/share/juju.sh
@@ -99,13 +99,13 @@ configureJuju()
 	env_type=$1
 	shift
 
-	if [ ! -e "/home/$INSTALL_USER/.juju" ]; then
-		mkdir -m 0700 "/home/$INSTALL_USER/.juju"
-		chown "$INSTALL_USER:$INSTALL_USER" "/home/$INSTALL_USER/.juju"
+	if [ ! -e "$INSTALL_HOME/.juju" ]; then
+		mkdir -m 0700 "$INSTALL_HOME/.juju"
+		chown "$INSTALL_USER:$INSTALL_USER" "$INSTALL_HOME/.juju"
 	fi
-	(umask 0077; $env_type $@ > "/home/$INSTALL_USER/.juju/environments.yaml")
+	(umask 0077; $env_type $@ > "$INSTALL_HOME/.juju/environments.yaml")
 	chown "$INSTALL_USER:$INSTALL_USER" \
-	    "/home/$INSTALL_USER/.juju/environments.yaml"
+	    "$INSTALL_HOME/.juju/environments.yaml"
 }
 
 # Bootstrap Juju inside container
@@ -155,8 +155,8 @@ jujuBootstrap()
 	python2 /etc/maas/templates/commissioning-user-data/snippets/maas_signal.py \
 	    --config $TMP/maas.creds OK || true
 
-	(cd "/home/$INSTALL_USER"; sudo -H -u "$INSTALL_USER" juju --show-log sync-tools)
-	(cd "/home/$INSTALL_USER"; sudo -H -u "$INSTALL_USER" juju bootstrap --upload-tools) &
+	(cd "$INSTALL_HOME"; sudo -H -u "$INSTALL_USER" juju --show-log sync-tools)
+	(cd "$INSTALL_HOME"; sudo -H -u "$INSTALL_USER" juju bootstrap --upload-tools) &
 	waitForNodeStatus $system_id 6
 	rm -rf /var/lib/lxc/juju-bootstrap/rootfs/var/lib/cloud/seed/*
 	cp $TMP/maas.creds \

--- a/share/maas.sh
+++ b/share/maas.sh
@@ -189,7 +189,7 @@ createMaasBridge()
 #
 createMaasSuperUser()
 {
-	password=$(cat "/home/$INSTALL_USER/.cloud-install/openstack.passwd")
+	password=$(cat "$INSTALL_HOME/.cloud-install/openstack.passwd")
 	printf "%s\n%s\n" "$password" "$password" \
 	    | setsid sh -c "maas-region-admin createsuperuser --username root --email root@example.com 1>&2"
 }

--- a/share/multi.sh
+++ b/share/multi.sh
@@ -83,7 +83,7 @@ multiInstall()
 		dialogGaugePrompt 75 "Bootstrapping Juju"
 		jujuBootstrap $uuid
 		maas maas tags new name=use-fastpath-installer definition="true()"
-		chown $INSTALL_USER:$INSTALL_USER /home/$INSTALL_USER/.maascli.db
+		chown $INSTALL_USER:$INSTALL_USER $INSTALL_HOME/.maascli.db
 
 		dialogGaugePrompt 100 "Installation complete"
 	} > "$TMP/gauge"
@@ -98,10 +98,10 @@ multiInstall()
 #
 saveMaasCreds()
 {
-	echo $1 > "/home/$INSTALL_USER/.cloud-install/maas-creds"
-	chmod 0600 "/home/$INSTALL_USER/.cloud-install/maas-creds"
+	echo $1 > "$INSTALL_HOME/.cloud-install/maas-creds"
+	chmod 0600 "$INSTALL_HOME/.cloud-install/maas-creds"
 	chown "$INSTALL_USER:$INSTALL_USER" \
-	    "/home/$INSTALL_USER/.cloud-install/maas-creds"
+	    "$INSTALL_HOME/.cloud-install/maas-creds"
 }
 
 # Setup multi install
@@ -112,15 +112,15 @@ saveMaasCreds()
 #
 setupMultiInstall()
 {
-	mkdir -m 0700 -p "/home/$INSTALL_USER/.cloud-install"
-	touch "/home/$INSTALL_USER/.cloud-install/multi"
+	mkdir -m 0700 -p "$INSTALL_HOME/.cloud-install"
+	touch "$INSTALL_HOME/.cloud-install/multi"
 	echo "$openstack_password" \
-	    > "/home/$INSTALL_USER/.cloud-install/openstack.passwd"
-	chmod 0600 "/home/$INSTALL_USER/.cloud-install/openstack.passwd"
+	    > "$INSTALL_HOME/.cloud-install/openstack.passwd"
+	chmod 0600 "$INSTALL_HOME/.cloud-install/openstack.passwd"
 	chown -R "$INSTALL_USER:$INSTALL_USER" \
-	    "/home/$INSTALL_USER/.cloud-install"
+	    "$INSTALL_HOME/.cloud-install"
 	configCharmOptions $openstack_password > \
-          "/home/$INSTALL_USER/.cloud-install/charmconf.yaml"
+          "$INSTALL_HOME/.cloud-install/charmconf.yaml"
 }
 
 # Configure interface

--- a/share/single.sh
+++ b/share/single.sh
@@ -24,15 +24,15 @@
 #
 setupSingleInstall()
 {
-	mkdir -m 0700 -p "/home/$INSTALL_USER/.cloud-install"
-	touch "/home/$INSTALL_USER/.cloud-install/single"
+	mkdir -m 0700 -p "$INSTALL_HOME/.cloud-install"
+	touch "$INSTALL_HOME/.cloud-install/single"
 	echo "$openstack_password" \
-	    > "/home/$INSTALL_USER/.cloud-install/openstack.passwd"
-	chmod 0600 "/home/$INSTALL_USER/.cloud-install/openstack.passwd"
+	    > "$INSTALL_HOME/.cloud-install/openstack.passwd"
+	chmod 0600 "$INSTALL_HOME/.cloud-install/openstack.passwd"
 	chown -R "$INSTALL_USER:$INSTALL_USER" \
-	    "/home/$INSTALL_USER/.cloud-install"
+	    "$INSTALL_HOME/.cloud-install"
 	configCharmOptions $openstack_password > \
-          "/home/$INSTALL_USER/.cloud-install/charmconf.yaml"
+          "$INSTALL_HOME/.cloud-install/charmconf.yaml"
 }
 
 # Single system install
@@ -54,7 +54,7 @@ singleInstall()
 		dialogGaugePrompt 80 "Bootstrapping Juju"
 		configureJuju configLocalEnvironment $openstack_password
                 (
-                  cd "/home/$INSTALL_USER"
+                  cd "$INSTALL_HOME"
                   sudo -H -u "$INSTALL_USER" juju bootstrap
                 )
 		echo 99


### PR DESCRIPTION
This allows running the installer from users with a home not in /home.
