### PR TITLE
Show requested constraint info in error message for failed add-machine

### DIFF
--- a/cloudinstall/gui.py
+++ b/cloudinstall/gui.py
@@ -395,7 +395,7 @@ class Node(WidgetWrap):
                 if "409" in unit_machine.agent_state_info and \
                    charm_class is not None:
                     info += "\nERROR: found no machines meeting constraints:\n"
-                    info += ', '.join(["{}='{}'".format(k,v) for k,v
+                    info += ', '.join(["{}='{}'".format(k, v) for k, v
                                        in charm_class.constraints.items()])
                 else:
                     info += "\nmachine info: " + unit_machine.agent_state_info


### PR DESCRIPTION
If a user requests a new node via the f6 dialog, this displays something more useful than the raw MAAS error message.
For an example, here's a 'screenshot' of the status screen after I requested a nova-compute with a :truck:-load of RAM:
http://paste.ubuntu.com/7839050/
