### PR TITLE
Use password from .jenv files for juju api access

### DIFF
--- a/cloudinstall/config.py
+++ b/cloudinstall/config.py
@@ -32,6 +32,9 @@ class Config:
         ('error',        'white',      'dark red'),
     ]
 
+    def __init__(self):
+        self._juju_env = None
+
     @property
     def tmpl_path(self):
         """ template path """
@@ -53,6 +56,9 @@ class Config:
     @property
     def juju_env(self):
         """ parses current juju environment """
+        if self._juju_env:
+            return self._juju_env
+
         env_file = None
         if self.is_single:
             env_file = 'local.jenv'
@@ -68,12 +74,17 @@ class Config:
 
         if os.path.exists(env_path):
             with open(env_path) as f:
-                return yaml.load(f.read().strip())
+                self._juju_env = yaml.load(f.read().strip())
+            return self._juju_env
         raise ConfigException('Unable to load environments file. Is '
                               'juju bootstrapped?')
 
     @property
-    def password(self):
+    def juju_api_password(self):
+        return self.juju_env['password']
+
+    @property
+    def openstack_password(self):
         PASSWORD_FILE = os.path.join(self.cfg_path, 'openstack.passwd')
         try:
             with open(PASSWORD_FILE) as f:

--- a/cloudinstall/core.py
+++ b/cloudinstall/core.py
@@ -100,7 +100,7 @@ class Controller:
             state_server = self.config.juju_env['state-servers'][0]
         self.juju = JujuClient(
             url=path.join('wss://', state_server),
-            password=self.config.password)
+            password=self.config.juju_api_password)
         self.juju.login()
         self.juju_state = JujuState(self.juju)
         log.debug('Authenticated against juju api.')


### PR DESCRIPTION
For non-local installs, the juju api password is not the same as the openstack password.
This just uses the password from the .jenv in both local and non-local.

It also caches the .jenv data in the config obj to avoid re-reading it all the time, which seems OK to me but without knowing how juju handles those files, it could be a source of subtle bugs and may not be worth the tiny runtime savings.

Opinions?
