### PR TITLE
handle case where 'cloud-install -u' is called when no file exists

### DIFF
--- a/tools/cloud-uninstall
+++ b/tools/cloud-uninstall
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-if [ "$#" -eq 1 ]; then
+if [ "$#" -eq 1 ] && [ $1 != '-u' ]; then
   WHAT=$1
+elif [ "$#" -eq 2 ]; then
+  WHAT=$2
 elif [ -f ~/.cloud-install/multi ]; then
   WHAT=multi-system
 elif [ -f ~/.cloud-install/single ]; then


### PR DESCRIPTION
since cloud-install calls this script with either '-u' or '-u install-type' , we check what $1 is.
if #args is 1 and it's not -u, then we're probably calling this script directly as before, and $1 is the install type, so grab that into WHAT
if #args is 1 and it is -u, we need to rely on the autodetect.

if #args is 2, we're probably getting a specific type from the script, so just use $2.
