### PR TITLE
Rework deployment to require mysql before keystone

### DIFF
--- a/bin/cloud-status
+++ b/bin/cloud-status
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 import signal
 import sys
 import argparse
@@ -44,6 +45,8 @@ def parse_options(*args, **kwds):
 
 if __name__ == '__main__':
     log.setup_logger()
+    logger = logging.getLogger('cloudinstall')
+    logger.info("cloud-status starting")
     if not os.path.exists(os.path.expanduser('~/.cloud-install')):
         print("It looks like you don't have a cloud installed.")
         print("Plese run `sudo cloud-install` and then cloud-status")

--- a/cloudinstall/charms/__init__.py
+++ b/cloudinstall/charms/__init__.py
@@ -165,10 +165,17 @@ export OS_REGION_NAME=RegionOne
         return class_.__name__.lower()
 
     def setup(self):
-        """ Deploy charm and configuration options
+        """Deploy charm and configuration options
 
         The default should be sufficient but if more functionality
         is needed this should be overridden.
+
+        returns True if deploy command was deferred for some reason.
+        returns False if no error occurred and deploy command was issued.
+
+        Note that the False (no-error) return value does not indicate
+        that service is up and running.
+
         """
         kwds = {}
         kwds['machine_id'] = self.machine_id
@@ -183,6 +190,8 @@ export OS_REGION_NAME=RegionOne
             self.client.deploy(self.charm_name, kwds)
         else:
             self.client.deploy(self.charm_name, kwds)
+
+        return False
 
     def set_relations(self):
         """ Setup charm relations

--- a/cloudinstall/charms/ceph.py
+++ b/cloudinstall/charms/ceph.py
@@ -43,12 +43,13 @@ class CharmCeph(CharmBase):
         """ Custom setup for ceph """
         if not self.has_quorum():
             log.debug("Insufficient machines allocated - ceph can't deploy.")
-            return
+            return True
         if not self.is_multi:
             log.debug("Ceph not currently supported on single installs")
-            return
+            return True
 
         self.client.deploy(self.charm_name,
                            dict(instances=self.default_instances))
+        return False
 
 __charm_class__ = CharmCeph

--- a/cloudinstall/charms/glance_simplestreams_sync.py
+++ b/cloudinstall/charms/glance_simplestreams_sync.py
@@ -91,8 +91,7 @@ class CharmGlanceSimplestreamsSync(CharmBase):
         except:
             log.exception("problem downloading stable branch."
                           " Falling back to charm store version.")
-            super(CharmGlanceSimplestreamsSync, self).setup()
-            return
+            return super(CharmGlanceSimplestreamsSync, self).setup()
 
         kwds = dict(machine_id=self.machine_id,
                     repodir=CHARMS_DIR,
@@ -116,6 +115,9 @@ class CharmGlanceSimplestreamsSync(CharmBase):
         except subprocess.CalledProcessError as e:
             log.warning("Deploy error. rc={} out={}".format(e.returncode,
                                                             e.output))
+            return True
+
+        return False
 
     def set_relations(self):
         if os.path.exists(os.path.join(CHARMS_DIR, CURRENT_DISTRO,

--- a/cloudinstall/charms/jujugui.py
+++ b/cloudinstall/charms/jujugui.py
@@ -25,6 +25,6 @@ class CharmJujuGui(CharmBase):
     charm_name = 'juju-gui'
     display_name = 'Juju GUI'
     display_priority = DisplayPriorities.Other
-    deploy_priority = 0         # deploy before all other charms
+    deploy_priority = 101         # deploy before all other charms except mysql
 
 __charm_class__ = CharmJujuGui

--- a/cloudinstall/charms/keystone.py
+++ b/cloudinstall/charms/keystone.py
@@ -16,7 +16,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
+
 from cloudinstall.charms import CharmBase
+
+log = logging.getLogger('cloudinstall.charms.keystone')
 
 
 class CharmKeystone(CharmBase):
@@ -26,10 +30,15 @@ class CharmKeystone(CharmBase):
     display_name = 'Keystone'
     related = ['mysql']
 
+    # must be > mysql or keystone will never deploy
+    deploy_priority = 200
+
     def setup(self):
         mysql = self.wait_for_agent('mysql')
         if not mysql:
+            log.debug("mysql not yet available, deferring keystone deploy")
             return True
-        super().setup()
+        log.debug("mysql is available, deploying keystone")
+        return super().setup()
 
 __charm_class__ = CharmKeystone

--- a/cloudinstall/charms/mysql.py
+++ b/cloudinstall/charms/mysql.py
@@ -25,4 +25,7 @@ class CharmMysql(CharmBase):
     charm_name = 'mysql'
     display_name = 'MySQL'
 
+    # must be < keystone, or keystone will never deploy
+    deploy_priority = 100
+
 __charm_class__ = CharmMysql

--- a/cloudinstall/charms/swift.py
+++ b/cloudinstall/charms/swift.py
@@ -48,6 +48,7 @@ class CharmSwift(CharmBase):
             kwds['configfile'] = CHARM_CONFIG_FILENAME
 
         self.client.deploy(self.charm_name, kwds)
+        return False
 
     def post_proc(self):
         self.client.set_config('glance-simplestreams-sync',


### PR DESCRIPTION
Fixes bug where keystone never deployed correctly, because it waited
for mysql but was incorrectly marked as being deployed anyway.

Includes multiple changes to do so:
## charm.setup() changes

Change Charm.setup() to always explicitly return success or failure*,
and check it in the initial deploy. Currently it was only checked in
the charm queue, which is not used in the initial deploy.
- \- failure to issue deploy. we don't know about deploy results here.

If setup() returns True (aka error or defer), _process() does not add
the charm to the list of deployed charms and instead returns True to
keep polling. This waits for mysql to be available before deploying
keystone.

Change all charms with custom setup() functions to explicitly return
an error / success bool. (This also fixed a latent bug in the unused
ceph charm which had an empty return on errors, which would've
returned None, ie, not an error)

Does not handle exceptions in setup(), I'm assuming they are
considered to be fatal.
## gui.py changes: Reorders deploy priorities and ordering

mysql should deploy before keystone, which deploys before others.

keystone waits for mysql to be _up_, not just deployed, before
deploying and unblocking the rest.
## more logging

Adds logging
Also adds code to make reading logs easier when they have multiple executions, like marking the start of a run.
## allows deploying more than 9 services

removes hardcoded '9' for list of services to attempt to deploy.
in my testing, self.done is sufficient, I'm not sure why the number was added.
