### PR TITLE
Show useful error info for MAAS errors. Also some cleanup.

### DIFF
--- a/cloudinstall/gui.py
+++ b/cloudinstall/gui.py
@@ -310,9 +310,9 @@ class NodeViewMode(ScrollableWidgetWrap):
 
         err_info = ""
 
-        if (unit.agent_state == 'pending' and
-            unit_machine.agent_state is '' and
-            unit_machine.agent_state_info is not None):
+        if unit.agent_state == 'pending' and \
+           unit_machine.agent_state is '' and \
+           unit_machine.agent_state_info is not None:
 
             # detect MAAS API errors, returned as 409 conflict:
             if "409" in unit_machine.agent_state_info:


### PR DESCRIPTION
- some varabile renaming for clarity
- sorts units so they don't bounce around in dictionary (arb) order
- shows error for maas machines that can't be found, whose juju units will be forever stuck in pending
- uses charm class to get constraint info to give helpful info instead of 409 error

here's what it looks like:

![screenshot-error-ui](https://cloud.githubusercontent.com/assets/1768106/3896482/af276162-2258-11e4-8849-ae836981fefb.png)
