### PR TITLE
make sure subsequent cloud-status invocations work

### DIFF
--- a/bin/cloud-install
+++ b/bin/cloud-install
@@ -61,7 +61,7 @@ def prep_userdata(dst):
     """ preps userdata file for container install """
     dst_file = os.path.join(dst, 'userdata.yaml')
     original_data = utils.load_template('userdata.yaml')
-    modified_data = original_data.render(extra_sshkeys=[ssh_readkey()])
+    modified_data = original_data.render(extra_sshkeys=[utils.ssh_readkey()])
     with open(dst_file, 'w') as f:
         f.write(modified_data)
 
@@ -75,48 +75,6 @@ def cloud_init_finished():
     if 'finished at' in out['stdout']:
         return True
     return False
-
-
-def ssh_readkey():
-    """ reads ssh key
-    """
-    with open(ssh_pubkey(), 'r') as f:
-        return f.read()
-
-
-def ssh_genkey():
-    """ Generates sshkey
-    """
-    if not os.path.exists(ssh_privkey()):
-        user_sshkey_path = os.path.join(utils.install_home(), '.ssh/id_rsa')
-        cmd = "ssh-keygen -N '' -f {0}".format(user_sshkey_path)
-        out = utils.get_command_output(cmd, user_sudo=True)
-        if out['ret'] != 0:
-            print("Unable to generate key: {0}".format(out['stderr']))
-            sys.exit(out['ret'])
-        utils.get_command_output('sudo chown -R {0}:{0} {1}'.format(
-            utils.install_user(), os.path.join(utils.install_home(), '.ssh')))
-        utils.get_command_output('chmod 600 {0}.pub'.format(user_sshkey_path),
-                                 user_sudo=True)
-    else:
-        print('')
-        print('*** ssh keys exist for this user, they will be used instead')
-        print('*** If the current ssh keys are not passwordless you\'ll be')
-        print('*** required to enter your ssh key password during container')
-        print('*** creation.')
-        print('')
-
-
-def ssh_pubkey():
-    """ returns path of ssh public key
-    """
-    return os.path.join(utils.install_home(), '.ssh/id_rsa.pub')
-
-
-def ssh_privkey():
-    """ returns path of private key
-    """
-    return os.path.join(utils.install_home(), '.ssh/id_rsa')
 
 
 def parse_options(*args, **kwds):
@@ -162,7 +120,7 @@ if __name__ == '__main__':
         print("if you wish to restart the installation.")
         sys.exit(1)
     print("* Please wait while we generate your isolated environment ...")
-    ssh_genkey()
+    utils.ssh_genkey()
     prep_userdata(user_install_dir)
     create_container()
     start()
@@ -182,5 +140,6 @@ if __name__ == '__main__':
         bootstrap_bin = '{0} -r {1}'.format(bootstrap_bin, opts.release)
     if opts.enable_swift:
         bootstrap_bin = '{0} -s'.format(bootstrap_bin)
-    out = utils.container_run(CONTAINER_NAME, bootstrap_bin, ssh_privkey())
+    out = utils.container_run(CONTAINER_NAME, bootstrap_bin,
+                              utils.ssh_privkey())
     sys.exit(0)

--- a/bin/cloud-install-bootstrapped
+++ b/bin/cloud-install-bootstrapped
@@ -134,5 +134,5 @@ fi
 if [ -z "$install" ]; then
 	exitInstall
 	sudo -H -u "$INSTALL_USER" juju status >> /dev/null
-	cd "$INSTALL_HOME"; exec sudo -H -u "$INSTALL_USER"  cloud-status $enableswift
+	cd "$INSTALL_HOME"; exec sudo -H -u "$INSTALL_USER" /usr/share/cloud-installer/bin/cloud-status-bootstrapped $enableswift
 fi

--- a/bin/cloud-status
+++ b/bin/cloud-status
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 # -*- mode: python; -*-
 #
-# cloud-status - Displays status of all managed nodes
-#
 # Copyright 2014 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
@@ -18,56 +16,15 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import argparse
-import logging
-import os
-import signal
 import sys
 
-
-from cloudinstall.gui import PegasusGUI
-from cloudinstall.console import Console
-from cloudinstall.core import Controller
 from cloudinstall import utils
-from cloudinstall import log
 
+CONTAINER_NAME = 'uoi-bootstrap'
 
-def sig_handler(signum, frame):
-    utils.reset_blanking()
-    sys.exit(1)
-
-for sig in (signal.SIGTERM, signal.SIGQUIT, signal.SIGINT, signal.SIGHUP):
-    signal.signal(sig, sig_handler)
-
-
-def parse_options(*args, **kwds):
-    parser = argparse.ArgumentParser(description='Ubuntu Openstack Installer',
-                                     prog='cloud-status')
-    parser.add_argument('--enable-swift', action='store_true',
-                        dest='enable_swift', default=False,
-                        help='Enable swift storage')
-    parser.add_argument('--no-ui', action='store_true',
-                        dest='noui', default=False,
-                        help='Perform installation without UI.')
-    return parser.parse_args()
 
 if __name__ == '__main__':
-    log.setup_logger()
-    logger = logging.getLogger('cloudinstall')
-    logger.info("cloud-status starting")
-    if not os.path.exists('/etc/cloud-installer'):
-        print("It looks like you don't have a cloud installed.")
-        print("Plese run `sudo cloud-install` and then cloud-status")
-        sys.exit(1)
-    opts = parse_options(sys.argv)
-    if opts.noui:
-        gui = Console()
-    else:
-        gui = PegasusGUI()
-    core = Controller(ui=gui, opts=opts)
-    try:
-        sys.exit(core.start())
-    except:
-        print("There was a problem running the status screen.")
-        print("Please check ~/.cloud-install/commands.log")
-        sys.exit(1)
+    bootstrap_bin = '/usr/share/cloud-installer/bin/cloud-status-bootstrapped'
+    out = utils.container_run(
+        CONTAINER_NAME, bootstrap_bin, utils.ssh_privkey())
+    sys.exit(0)

--- a/bin/cloud-status-bootstrapped
+++ b/bin/cloud-status-bootstrapped
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# -*- mode: python; -*-
+#
+# cloud-status - Displays status of all managed nodes
+#
+# Copyright 2014 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import logging
+import os
+import signal
+import sys
+
+
+from cloudinstall.gui import PegasusGUI
+from cloudinstall.console import Console
+from cloudinstall.core import Controller
+from cloudinstall import utils
+from cloudinstall import log
+
+
+def sig_handler(signum, frame):
+    utils.reset_blanking()
+    sys.exit(1)
+
+for sig in (signal.SIGTERM, signal.SIGQUIT, signal.SIGINT, signal.SIGHUP):
+    signal.signal(sig, sig_handler)
+
+
+def parse_options(*args, **kwds):
+    parser = argparse.ArgumentParser(description='Ubuntu Openstack Installer',
+                                     prog='cloud-status')
+    parser.add_argument('--enable-swift', action='store_true',
+                        dest='enable_swift', default=False,
+                        help='Enable swift storage')
+    parser.add_argument('--no-ui', action='store_true',
+                        dest='noui', default=False,
+                        help='Perform installation without UI.')
+    return parser.parse_args()
+
+if __name__ == '__main__':
+    log.setup_logger()
+    logger = logging.getLogger('cloudinstall')
+    logger.info("cloud-status starting")
+    if not os.path.exists('/etc/cloud-installer'):
+        print("It looks like you don't have a cloud installed.")
+        print("Plese run `sudo cloud-install` and then cloud-status")
+        sys.exit(1)
+    opts = parse_options(sys.argv)
+    if opts.noui:
+        gui = Console()
+    else:
+        gui = PegasusGUI()
+    core = Controller(ui=gui, opts=opts)
+    try:
+        sys.exit(core.start())
+    except:
+        print("There was a problem running the status screen.")
+        print("Please check ~/.cloud-install/commands.log")
+        sys.exit(1)

--- a/debian/cloud-installer.install
+++ b/debian/cloud-installer.install
@@ -1,6 +1,7 @@
 bin/cloud-install                      usr/share/cloud-installer
 bin/cloud-install-bootstrapped         usr/share/cloud-installer/bin
 bin/cloud-status                       usr/share/cloud-installer
+bin/cloud-status-bootstrapped          usr/share/cloud-installer/bin
 bin/configure-landscape                usr/share/cloud-installer/bin
 bin/ip_range.py                        usr/share/cloud-installer/bin
 bin/maas-report-boot-images            usr/share/cloud-installer/bin


### PR DESCRIPTION
Simply handles the cases where someone exits cloud-status
and then re-opens it to make sure that our application
runs properly within the container.

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
