### PR TITLE
use execvp and drop privs for calling status

### DIFF
--- a/cloudinstall/multi_install.py
+++ b/cloudinstall/multi_install.py
@@ -131,8 +131,8 @@ class MultiInstall:
         user_name = os.getenv("SUDO_USER")
         pwnam = pwd.getpwnam(user_name)
         os.initgroups(user_name, pwnam.pw_gid)
-        os.setresgid(pwnam.pw_gid)
-        os.setresuid(pwnam.pw_uid)
+        os.setregid(pwnam.pw_gid, pwnam.pw_gid)
+        os.setreuid(pwnam.pw_uid, pwnam.pw_uid)
 
 
 class MultiInstallExistingMaas(MultiInstall):


### PR DESCRIPTION
RFC. I don't see how the earlier version worked, but I assume it did work with the existing maas path?

Anyway, I've seen this work once but am having problems testing it because juju will occasionally fail to bootstrap, which is probably unrelated. That's why this is just a PR.
