### PR TITLE
run apt-go-fast on all machines

### DIFF
--- a/cloudinstall/core.py
+++ b/cloudinstall/core.py
@@ -389,8 +389,9 @@ class Controller(DisplayController):
         if self.config.is_single:
             controller_machine = self.juju_m_idmap['controller']
             self.configure_lxc_network(controller_machine)
-            for juju_machine_id in self.juju_m_idmap.values():
-                self.run_apt_go_fast(controller_machine)
+
+        for juju_machine_id in self.juju_m_idmap.values():
+            self.run_apt_go_fast(juju_machine_id)
 
         self.deploy_using_placement()
         self.enqueue_deployed_charms()


### PR DESCRIPTION
in the old code, we only ran it on the controller, in both single and multi:
https://github.com/Ubuntu-Solutions-Engineering/openstack-installer/blob/stable/cloudinstall/core.py#L326

in the new code, prior to this PR, it's really weird, probably a copy and paste error. the intent was to run it on every machine we knew about, for single and multi.
Because we have the placement code, we know about all the machines we'll need, and so we can run it on all the machines we're going to use before deploying.

BUT what it does now is run it only in single (skipping multi) and runs it only on the controller machine, but does it N times if there are N machines.
In practice this means it runs it 3 times on the controller.
