### PR TITLE
merge multi install paths into one

### DIFF
--- a/cloudinstall/config.py
+++ b/cloudinstall/config.py
@@ -70,7 +70,7 @@ class Config:
     def install_types(self):
         """ Installer types
         """
-        return ['Single', 'Multi', 'Multi with existing MAAS', 'Landscape']
+        return ['Single', 'Multi', 'Landscape']
 
     @property
     def share_path(self):

--- a/cloudinstall/install.py
+++ b/cloudinstall/install.py
@@ -49,6 +49,18 @@ class InstallController(DisplayController):
             return self.show_password_input(
                 'Create a new Openstack Password', self._save_password)
 
+    def _save_maas_creds(self, creds):
+        self.ui.hide_widget_on_top()
+        maas_server = creds['maas_server'].value
+        maas_apikey = creds['maas_apikey'].value
+
+        if maas_server and maas_apikey:
+            self.config.save_maas_creds(maas_server,
+                                        maas_apikey)
+            MultiInstallExistingMaas(self.opts, self).run()
+        else:
+            MultiInstallNewMaas(self.opts, self).run()
+
     def select_install_type(self):
         """ Dialog for selecting installation type
         """
@@ -56,6 +68,17 @@ class InstallController(DisplayController):
         self.show_selector_info('Install Type',
                                 self.config.install_types,
                                 self.do_install)
+
+    def select_maas_type(self):
+        """ Perform multi install based on existing
+        MAAS or if a new MAAS will be installed
+        """
+        self.info_message(
+            "If a MAAS exists please enter the Server IP and your "
+            "administrator's API Key. Otherwise leave blank and a new "
+            "MAAS will be created for you.")
+        self.show_maas_input("MAAS Setup",
+                             self._save_maas_creds)
 
     def main_loop(self):
         if not hasattr(self, 'loop'):
@@ -78,12 +101,9 @@ class InstallController(DisplayController):
         if 'Single' in install_type:
             self.set_openstack_rel("Icehouse (2014.1.1)")
             SingleInstall(self.opts, self).run()
-        elif 'Multi with existing MAAS' == install_type:
-            self.set_openstack_rel("Icehouse (2014.1.1)")
-            MultiInstallExistingMaas(self.opts, self).run()
         elif 'Multi' == install_type:
             self.set_openstack_rel("Icehouse (2014.1.1)")
-            MultiInstallNewMaas(self.opts, self).run()
+            self.select_maas_type()
         else:
             self.set_openstack_rel("")
             LandscapeInstall(self.opts, self).run()

--- a/cloudinstall/multi_install.py
+++ b/cloudinstall/multi_install.py
@@ -172,39 +172,12 @@ class MultiInstallExistingMaas(MultiInstall):
     def do_install_async(self):
         self.do_install()
 
-    def _save_maas_creds(self, creds):
-        self.display_controller.ui.hide_widget_on_top()
-        maas_server = creds['maas_server'].value
-        maas_apikey = creds['maas_apikey'].value
-
-        self.config.save_maas_creds(maas_server,
-                                    maas_apikey)
-
-        # update_progress starts a timer, so should be called on 'main
-        # thread':
-        self.update_progress()
-        self.do_install_async()
-
     def run(self):
         self.register_tasks(["Starting Juju server"] +
                             self.post_tasks)
 
-        if self.config.is_landscape:
-            # This is a result of running a landscape install and
-            # entering maas information there.
-
-            # update_progress starts a timer, so should be called on
-            # 'main thread':
-            self.update_progress()
-            self.do_install_async()
-        else:
-            # Otherwise it's a plain OpenStack installation on an
-            # existing maas, and we need to ask for the info here.
-            self.display_controller.info_message("Please enter your MAAS "
-                                                 "Server IP and your "
-                                                 "administrator's API Key")
-            self.display_controller.show_maas_input("MAAS Install",
-                                                    self._save_maas_creds)
+        self.update_progress()
+        self.do_install_async()
 
 
 class MaasInstallError(Exception):

--- a/cloudinstall/ui/__init__.py
+++ b/cloudinstall/ui/__init__.py
@@ -181,8 +181,8 @@ class MaasServerInput(Dialog):
 
     def __init__(self, title, cb):
         super().__init__(title, cb)
-        self.add_input('maas_server', 'MAAS IP Address: ')
-        self.add_input('maas_apikey', 'MAAS API Key: ')
+        self.add_input('maas_server', 'MAAS Server IP (optional): ')
+        self.add_input('maas_apikey', 'MAAS API Key (optional): ')
         self.show()
 
 


### PR DESCRIPTION
This takes the same approach as the Landscape whereas if
a MAAS server ip and apikey are provided it will do the
MultiInstallWithExistingMaas, otherwise it assumes a new
MAAS install will be performed and continue down that
path.

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
