### PR TITLE
Fix filter label total

### DIFF
--- a/cloudinstall/placement/ui.py
+++ b/cloudinstall/placement/ui.py
@@ -396,7 +396,7 @@ class MachinesList(WidgetWrap):
             mw.update()
 
         self.filter_edit_box.set_info(len(self.machine_widgets),
-                                      len(n_satisfying_machines))
+                                      n_satisfying_machines)
 
     def add_machine_widget(self, machine):
         mw = MachineWidget(machine, self.controller, self.actions,


### PR DESCRIPTION
Make the total in the label match the number of machines displayed in the list by counting the number of machines that satisfy the constraints.

Previously it could end up saying (10 of 12 shown) even when there was no text in the filter, because two machines did not match the constraints.
