### PR TITLE
Remove unnecessary PPA for single-installer

### DIFF
--- a/docs/single-installer.guide.rst
+++ b/docs/single-installer.guide.rst
@@ -8,7 +8,6 @@ Add the Openstack installer ppa to your system.
 
 .. code::
 
-   $ sudo apt-add-repository ppa:juju/stable
    $ sudo apt-add-repository ppa:cloud-installer/testing
    $ sudo apt-get update
 


### PR DESCRIPTION
juju-core and juju-deployer will be installed as dependencies of "openstack" package anyway, but those will not be used on the host.
