### PR TITLE
Add ability to define custom dhcp ranges

### DIFF
--- a/cloudinstall/core.py
+++ b/cloudinstall/core.py
@@ -86,6 +86,7 @@ def view_context(view):
 
 
 class FakeJujuState:
+
     @property
     def services(self):
         return []
@@ -220,6 +221,10 @@ class DisplayController:
     def show_selector_info(self, title, install_types, cb):
         with dialog_context(self):
             self.ui.show_selector_info(title, install_types, cb)
+
+    def show_dhcp_range(self, range_low, range_high, title, cb):
+        with dialog_context(self):
+            self.ui.show_dhcp_range(range_low, range_high, title, cb)
 
     def show_exception_message(self, ex):
         def handle_done(*args, **kwargs):

--- a/cloudinstall/gui.py
+++ b/cloudinstall/gui.py
@@ -41,6 +41,7 @@ from cloudinstall.ui import (ScrollableWidgetWrap,
                              PasswordInput,
                              MaasServerInput,
                              LandscapeInput,
+                             DhcpRangeInput,
                              InfoDialog)
 from cloudinstall.ui.helpscreen import HelpScreen
 from cloudinstall.placement.ui import PlacementView
@@ -648,6 +649,13 @@ class PegasusGUI(WidgetWrap):
         self.show_widget_on_top(widget, width=50, height=10)
 
     def hide_show_maas_input(self):
+        self.hide_widget_on_top()
+
+    def show_dhcp_range(self, range_low, range_high, title, cb):
+        widget = DhcpRangeInput(range_low, range_high, title, cb)
+        self.show_widget_on_top(widget, width=50, height=10)
+
+    def hide_show_dhcp_range(self):
         self.hide_widget_on_top()
 
     def show_landscape_input(self, title, cb):

--- a/cloudinstall/multi_install.py
+++ b/cloudinstall/multi_install.py
@@ -241,8 +241,7 @@ class MultiInstallNewMaas(MultiInstall):
         self.iface_ip = get_ip_addr(self.target_iface)
         self.iface_network = get_network(self.target_iface)
 
-        self.update_progress()
-        self.continue_with_interface()
+        self.prompt_for_dhcp_range()
 
     @utils.async
     def continue_with_interface(self):
@@ -323,6 +322,28 @@ class MultiInstallNewMaas(MultiInstall):
 
         self.do_install()
 
+    def prompt_for_dhcp_range(self):
+        """ Prompts for configurable dhcp ranges
+
+        :returns: Tuple of low/high ranges
+        """
+        self.display_controller.info_message(
+            "Set the minimum and maximumu dhcp ranges for your environment")
+
+        def set_dhcp_range(ranges):
+            self.dhcp_range = (ranges['dhcp_low'].value,
+                               ranges['dhcp_high'].value)
+
+            self.update_progress()
+            self.continue_with_interface()
+        nw = ip_network(self.iface_network, strict=False)
+        excludes = list(map(ip_address, [self.iface_ip]))
+        dhcp_range = ip_range_max(nw, excludes)
+        self.display_controller.show_dhcp_range(str(dhcp_range[0]),
+                                                str(dhcp_range[1]),
+                                                "Define DHCP Range",
+                                                set_dhcp_range)
+
     def prompt_for_bridge(self):
         # TODO prompt user to ask about bridging maas nw interface
         self.should_bridge_maasnw = True
@@ -335,23 +356,24 @@ class MultiInstallNewMaas(MultiInstall):
             self.enable_ipv4_forwarding()
             log.debug("enabled forwarding")
             self.gateway = get_ip_addr('br0')
-            excludes = [self.iface_ip]
+            # excludes = [self.iface_ip]
         else:
             self.gateway = get_default_gateway()
-            excludes = [self.iface_ip, self.gateway]
+            # excludes = [self.iface_ip, self.gateway]
 
-        excludes = list(map(ip_address, excludes))
-        nw = ip_network(self.iface_network, strict=False)
-        self.dhcp_range = ip_range_max(nw, excludes)
-        # TODO: allow customization
+        # excludes = list(map(ip_address, excludes))
+        # nw = ip_network(self.iface_network, strict=False)
+        # self.dhcp_range = ip_range_max(nw, excludes)
 
-        self.display_controller.info_message("Detecting Existing DHCP server")
+        self.display_controller.info_message(
+            "Detecting Existing DHCP server")
         self.start_task("Searching for existing DHCP servers")
         # TODO Handle existing dhcp with another dialog or user interaction
         # to accept the consequences.
         if self.detect_existing_dhcp(self.target_iface):
-            log.error("An existing DHCP server was found on this interface, "
-                      "the network may be incorrectly configured.")
+            log.error(
+                "An existing DHCP server was found on this interface, "
+                "the network may be incorrectly configured.")
             pass
 
     def create_bootstrap_kvm(self):

--- a/cloudinstall/ui/__init__.py
+++ b/cloudinstall/ui/__init__.py
@@ -199,3 +199,15 @@ class LandscapeInput(Dialog):
         self.add_input('maas_server', 'MAAS Server IP (optional): ')
         self.add_input('maas_apikey', 'MAAS API Key (optional): ')
         self.show()
+
+
+class DhcpRangeInput(Dialog):
+
+    """ DHCP Range dialog
+    """
+
+    def __init__(self, low, high, title, cb):
+        super().__init__(title, cb)
+        self.add_input('dhcp_low', 'DHCP Range Low IP: ', edit_text=low)
+        self.add_input('dhcp_high', 'DHCP Range High IP: ', edit_text=high)
+        self.show()


### PR DESCRIPTION
Allows the user to set smaller dhcp ranges so that openstack
may have the ability to define floating ips based on the remaining
pool.

Fixes: #220
Fixes: #218

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
