### PR TITLE
Fix path for cd in developer docs

### DIFF
--- a/docs/developer.setup.rst
+++ b/docs/developer.setup.rst
@@ -28,7 +28,7 @@ installer:
 .. code::
 
    $ git clone https://github.com/Ubuntu-Solutions-Engineering/openstack-installer.git ~/openstack-installer
-   $ cd openstack
+   $ cd ~/openstack-installer
 
 Use the target 'install-dependencies' to install a custom binary package for the build dependencies:
 


### PR DESCRIPTION
The dev docs had a typo in them.

Fixes #222
