### PR TITLE
Allow maas uninstall prompt

### DIFF
--- a/tools/openstack-uninstall
+++ b/tools/openstack-uninstall
@@ -116,4 +116,5 @@ if [ ${RET} -eq 0 ]; then
   fi
 fi
 
+rm -rf ~/.juju ~/.cloud-install || true
 rm -rf /etc/openstack || true


### PR DESCRIPTION
Maas packaging doesn't work non-interactively.
You have to say YES to both questions it asks you to really be rid of its DB, and apparently one of the defaults used is NO.
Our best bet for now is to just warn the user, but for the long term we'd like to set the defaults.
