### PR TITLE
Fixes issue with reading credentials as incorrect user

### DIFF
--- a/cloudinstall/multi_install.py
+++ b/cloudinstall/multi_install.py
@@ -750,7 +750,7 @@ class LandscapeInstallFinal:
 
         log.debug("Running landscape configure: {}".format(cmd))
 
-        out = utils.get_command_output(cmd, timeout=None, user_sudo=True)
+        out = utils.get_command_output(cmd, timeout=None)
 
         if out['status']:
             log.error("Problem with configuring Landscape: {}.".format(out))


### PR DESCRIPTION
During the configuring of Landscape portion it was attempting to
run as an incorrect user.

Fixes #214

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
