### PR TITLE
adds persistent flash messages to failed inputs

### DIFF
--- a/cloudinstall/core.py
+++ b/cloudinstall/core.py
@@ -204,6 +204,15 @@ class DisplayController:
                                                      logpath))
             self.ui.show_fatal_error_message(msg, handle_done)
 
+    # - Body
+    def flash(self, text):
+        with view_context(self):
+            self.ui.flash(text)
+
+    def flash_reset(self):
+        with view_context(self):
+            self.ui.flash_reset()
+
     # - Footer
     def clear_status(self):
         self.ui.clear_status()

--- a/cloudinstall/gui.py
+++ b/cloudinstall/gui.py
@@ -156,7 +156,7 @@ class Banner(ScrollableWidgetWrap):
 
     def __init__(self):
         self.text = []
-
+        self.flash_text = Text('', align='center')
         self.BANNER = [
             "",
             "",
@@ -164,7 +164,7 @@ class Banner(ScrollableWidgetWrap):
             "",
             "By Canonical, Ltd.",
             "",
-
+            ""
         ]
         super().__init__(self._create_text())
 
@@ -173,11 +173,18 @@ class Banner(ScrollableWidgetWrap):
         for line in self.BANNER:
             self._insert_line(line)
 
+        self.text.append(self.flash_text)
         return ScrollableListBox(self.text)
 
     def _insert_line(self, line):
         text = Text(line, align='center')
         self.text.append(text)
+
+    def flash(self, msg):
+        self.flash_text.set_text([('error', "Error: \n\n{}".format(msg))])
+
+    def flash_reset(self):
+        self.flash_text.set_text('')
 
 
 class NodeInstallWaitMode(ScrollableWidgetWrap):
@@ -688,6 +695,12 @@ class PegasusGUI(WidgetWrap):
 
     def set_pending_deploys(self, pending_charms):
         self.frame.footer.set_pending_deploys(pending_charms)
+
+    def flash(self, msg):
+        self.frame.body.flash(msg)
+
+    def flash_reset(self):
+        self.frame.body.flash_reset()
 
     def status_message(self, text):
         self.frame.footer.message(text)

--- a/cloudinstall/install.py
+++ b/cloudinstall/install.py
@@ -50,11 +50,12 @@ class InstallController(DisplayController):
         if 'confirm_password' in creds:
             confirm_password = creds['confirm_password'].value
         if password and password == confirm_password:
+            self.flash_reset()
             self.config.save_password(password)
             self.ui.hide_show_password_input()
             self.select_install_type()
         else:
-            self.error_message('Passwords did not match, try again ..')
+            self.flash('Passwords did not match, try again ..')
             return self.show_password_input(
                 'Create a new Openstack Password', self._save_password)
 

--- a/cloudinstall/landscape_install.py
+++ b/cloudinstall/landscape_install.py
@@ -67,9 +67,13 @@ class LandscapeInstall:
         self.display_controller.ui.hide_widget_on_top()
         self.display_controller.info_message("Running ..")
         if not maas_server:
-            log.debug("No maas credentials entered, doing a new MAAS install")
-            self._do_install_new_maas()
+            log.error("No maas credentials entered, restarting dialog.")
+            self.display_controller.flash(
+                "Missing required MAAS server information. Please fill out "
+                "MAAS Server IP and MAAS API Key.")
+            return self.run()
         else:
+            self.display_controller.flash_reset()
             log.debug("Existing MAAS defined, doing a LDS "
                       "installation with existing MAAS.")
             self.config.save_maas_creds(maas_server,


### PR DESCRIPTION
Adds a error text above the dialog box when failed
inputs occur (eg. missing required maas fields)

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com

Screenshots:
![required_maas_fail](https://cloud.githubusercontent.com/assets/51892/5120004/aaf34e7c-7040-11e4-8616-8e482e26e9ab.png)
![password_fail](https://cloud.githubusercontent.com/assets/51892/5120007/b795bf02-7040-11e4-96dd-407cc65e686c.png)
