### PR TITLE
add hidden env var to specify a node for juju bootstrap

### DIFF
--- a/cloudinstall/multi_install.py
+++ b/cloudinstall/multi_install.py
@@ -133,10 +133,10 @@ class MultiInstall(InstallBase):
             dbgflags = "--debug"
 
         bsflags = ""
-        # FIXME: this tag is never defined, removing to allow
-        # installers to work again
-        # if not self.installing_new_maas:
         #    bsflags = " --constraints tags=physical"
+        bstarget = os.getenv("JUJU_BOOTSTRAP_TO")
+        if bstarget:
+            bsflags += " --to {}".format(bstarget)
 
         out = utils.get_command_output("juju {} bootstrap {}".format(dbgflags,
                                                                      bsflags),


### PR DESCRIPTION
Handy for use in environments with e.g. VMs that you don't want juju to pick as the server node.
For example, the orange box
