### PR TITLE
fix crash when clearing assignments twice

### DIFF
--- a/cloudinstall/placement/controller.py
+++ b/cloudinstall/placement/controller.py
@@ -209,6 +209,12 @@ class PlacementController:
         self.update_and_save()
 
     def clear_assignments(self, m):
+        """clears all assignments for machine m.
+        If m has no assignments, does nothing.
+        """
+        if m.instance_id not in self.assignments:
+            return
+
         del self.assignments[m.instance_id]
         self.update_and_save()
 

--- a/test/test_placement_controller.py
+++ b/test/test_placement_controller.py
@@ -320,3 +320,12 @@ class PlacementControllerTestCase(unittest.TestCase):
         self.pc.assign(self.mock_machine, CharmSwiftProxy, AssignmentType.LXC)
         self.assertTrue(self.pc.is_assigned(CharmSwiftProxy,
                                             self.mock_machine))
+
+    def test_double_clear_ok(self):
+        """clearing assignments for a machine that isn't assigned (anymore) is
+        OK and should do nothing
+        """
+        self.pc.assign(self.mock_machine, CharmSwiftProxy, AssignmentType.LXC)
+        self.pc.clear_assignments(self.mock_machine)
+        self.pc.clear_assignments(self.mock_machine)
+        self.pc.clear_assignments(self.mock_machine_2)


### PR DESCRIPTION
- do not try to clear assignments for machine that has no assignments.
- add a test so we don't break it in the future
