### PR TITLE
let cloud-init manage /etc/hosts on container

### DIFF
--- a/share/templates/userdata.yaml
+++ b/share/templates/userdata.yaml
@@ -57,6 +57,7 @@ package_update: true
 password: ubuntu
 chpasswd: { expire: False }
 ssh_pwauth: True
+manage_etc_hosts: localhost
 
 bootcmd:
   - rm /etc/network/interfaces.d/{{ network_interface }}.cfg


### PR DESCRIPTION
this avoids the message 'unable to resolve host: uoi-bootstrap' from sudo.
this fixes #294 

Note that the lxc prep script for the ubuntu-cloud template apparently sets this by default, but doesn't set it if you use your own userdata:
https://github.com/lxc/lxc/blob/f50b163d1d565a9c5f3fbab725b999c5746961ad/hooks/ubuntu-cloud-prep#L141
