### PR TITLE
Return correct home dir

### DIFF
--- a/cloudinstall/utils.py
+++ b/cloudinstall/utils.py
@@ -596,7 +596,7 @@ def install_user():
 def install_home():
     """ returns installer user home
     """
-    return os.path.join('/home', install_user())
+    return os.path.expanduser("~"+install_user())
 
 
 def ssh_readkey():


### PR DESCRIPTION
At the moment, the installer is guessing what the home directory of the user is. This actually returns the correct home dir.
