### PR TITLE
add local theme for read-the-docs, and code to avoid using it ON RTD

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -122,6 +122,13 @@ pygments_style = 'perldoc'
 # a list of builtin themes.
 html_theme = 'default'
 
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+if not on_rtd:  # only import and set the theme if we're building docs locally
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ nose-cov
 readthedocs-sphinx-ext
 pyflakes>=0.8.1
 pep8>=1.5.6
+sphinx_rtd_theme
 macumba
 maasclient
 jinja2


### PR DESCRIPTION
so that 'make html' looks like how it'll look on RTD
