### PR TITLE
use lxc cache from host to speed up juju bootstrap

### DIFF
--- a/cloudinstall/single_install.py
+++ b/cloudinstall/single_install.py
@@ -99,6 +99,8 @@ class SingleInstall(InstallBase):
                 "{0} {1} none bind,create=dir\n".format(
                     os.path.join(utils.install_home(), '.ssh'),
                     'home/ubuntu/.ssh'))
+            f.write(
+                "/var/cache/lxc var/cache/lxc none bind,create=dir\n")
 
         lxc_logfile = os.path.join(self.config.cfg_path, 'lxc.log')
 


### PR DESCRIPTION
juju bootstrap takes about 22 seconds to complete now.

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
