### PR TITLE
flag status of deployment and treat most exceptions as a failed deploy

### DIFF
--- a/cloudinstall/charms/__init__.py
+++ b/cloudinstall/charms/__init__.py
@@ -358,4 +358,4 @@ class CharmQueue:
                 log.exception(msg)
                 self.ui.status_error_message(msg)
             time.sleep(10)
-        utils.finalize_status_out(True, 'Completed successfully.')
+        utils.write_status_file('success', 'Completed successfully.')

--- a/cloudinstall/utils.py
+++ b/cloudinstall/utils.py
@@ -49,7 +49,7 @@ blank_len = None
 def global_exchandler(type, value, tb):
     """ helper routine capturing tracebacks and printing to log file """
     tb_list = traceback.format_exception(type, value, tb)
-    finalize_status_out(msg="".join(tb_list))
+    write_status_file('fail', "".join(tb_list))
     log.debug("".join(tb_list))
 
 
@@ -84,10 +84,10 @@ def cleanup():
     os.system('stty sane')
 
 
-def finalize_status_out(status=False, msg=''):
+def write_status_file(status='', msg=''):
     """ Writes out a completed status file
 
-    :param bool status: Status of exit True=SUCCESS, False=FAIL
+    :param str status: success or fail
     :param str msg: any error/success output
     """
     status_file = os.path.join(install_home(), '.cloud-install/finished.json')


### PR DESCRIPTION
Writes the information into `finished.json` which can be utilized
during testing to determine the stage of the deploy (finished or not)

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
