### PR TITLE
just always retry after container IP errors

### DIFF
--- a/cloudinstall/single_install.py
+++ b/cloudinstall/single_install.py
@@ -129,10 +129,9 @@ class SingleInstall(InstallBase):
             log.debug(result_json)
 
         except utils.NoContainerIPException as e:
-            if tries < maxlenient:
-                log.debug("Container has no IP yet. waiting.")
-                return False
-            raise e
+            log.debug("Container has no IPs according to lxc-info. "
+                      "Will retry.")
+            return False
 
         except utils.ContainerRunException as e:
             _, returncode = e.args


### PR DESCRIPTION
Because of the potential for interfaces to be temporarily invisible, we will just treat a container with no IP as always a retry-able error.
If we see issues in the future where containers are losing networking, causing the installer to wait forever, we might consider keeping a counter to retry only N times, but for now that doesn't seem necessary.
And this code will at least let us know that that's what's happening if that does end up being a problem.