### PR TITLE
Don't mark ext-net as shared

### DIFF
--- a/share/templates/nova-controller-setup.sh
+++ b/share/templates/nova-controller-setup.sh
@@ -16,7 +16,7 @@ nova flavor-delete m1.tiny
 nova flavor-create m1.tiny 1 512 8 1
 
 # configure external network
-neutron net-create --router:external=True --shared ext-net
+neutron net-create --router:external=True ext-net
 neutron subnet-create --name ext-subnet --gateway 10.0.3.1 --allocation-pool start=10.0.3.200,end=10.0.3.254 --disable-dhcp ext-net 10.0.3.0/24
 
 # create ubuntu user

--- a/tools/cloud-sh/cloud-setup.sh
+++ b/tools/cloud-sh/cloud-setup.sh
@@ -7,7 +7,7 @@ nova flavor-delete m1.tiny
 nova flavor-create m1.tiny 1 512 8 1
 
 # configure external network
-neutron net-create --router:external=True --shared ext-net
+neutron net-create --router:external=True ext-net
 neutron subnet-create --name ext-subnet --gateway 10.0.3.1 --allocation-pool start=10.0.3.200,end=10.0.3.254 --disable-dhcp ext-net 10.0.3.0/24
 
 # create ubuntu user


### PR DESCRIPTION
It's not necessary to mark ext-net as shared. With this change, ext-net
will disappear from NIC selection dialogue in horizon, but tenant users
can still get floating IPs from ext-net.

Fixes #263 

![network-selection](https://cloud.githubusercontent.com/assets/4356209/5753747/5f4af840-9cd1-11e4-90b2-d8962d6c6981.png)
