### PR TITLE
ssh_genkey: don't assume that $USER == $GROUP

### DIFF
--- a/cloudinstall/utils.py
+++ b/cloudinstall/utils.py
@@ -719,7 +719,7 @@ def ssh_genkey():
         if out['status'] != 0:
             raise Exception(
                 "Unable to generate key: {0}".format(out['output']))
-        get_command_output('sudo chown -R {0}:{0} {1}'.format(
+        get_command_output('sudo chown -R {0} {1}'.format(
             install_user(), os.path.join(install_home(), '.ssh')))
         get_command_output('chmod 600 {0}.pub'.format(user_sshkey_path),
                            user_sudo=True)


### PR DESCRIPTION
In a lot of environments there is no specific user group.

Limit the access to user only, default ssh.

(Closes: LP#1413249)

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>