### PR TITLE
Patch populate config

### DIFF
--- a/bin/openstack-install
+++ b/bin/openstack-install
@@ -23,7 +23,6 @@ import sys
 import os
 import logging
 import signal
-import yaml
 from functools import partial
 from cloudinstall.log import setup_logger
 import cloudinstall.utils as utils
@@ -102,26 +101,9 @@ def parse_options(argv):
     return parser.parse_args(argv)
 
 
-def populate_config(opts):
-    presaved_config = os.path.join(
-        utils.install_home(), '.cloud-install/config.yaml')
-
-    # Always override presaved config if defined in cli switch
-    if opts.config_file and os.path.exists(opts.config_file):
-        _cfg = yaml.load(utils.slurp(opts.config_file))
-    # Pull from ~/.cloud-install/config.yaml if exists
-    elif os.path.exists(presaved_config):
-        _cfg = yaml.load(utils.slurp(presaved_config))
-    else:
-        _cfg = {}
-    # Update cfg dict with command line opts
-    _cfg.update(vars(opts))
-    return Config(cfg_obj=_cfg)
-
-
 if __name__ == '__main__':
     opts = parse_options(sys.argv[1:])
-    cfg = populate_config(opts)
+    cfg = Config(utils.populate_config(opts))
 
     try:
         setup_logger(headless=cfg.getopt('headless'))

--- a/bin/openstack-install
+++ b/bin/openstack-install
@@ -43,9 +43,10 @@ for sig in (signal.SIGTERM, signal.SIGQUIT, signal.SIGINT, signal.SIGHUP):
 
 def parse_options(argv):
     parser = argparse.ArgumentParser(description='Ubuntu Openstack Installer',
-                                     prog='openstack-install')
+                                     prog='openstack-install',
+                                     argument_default=argparse.SUPPRESS)
     parser.add_argument('-i', '--install-only', action='store_true',
-                        dest='install_only', default=False,
+                        dest='install_only',
                         help='install and bootstrap MAAS/Juju/Landscape '
                         '(as applicable) only. '
                         'Will not deploy any OpenStack services '
@@ -53,21 +54,21 @@ def parse_options(argv):
                         'You can invoke openstack-status manually to '
                         'continue.')
     parser.add_argument('-u', '--uninstall', action='store_true',
-                        dest='uninstall', default=False,
+                        dest='uninstall',
                         help='Uninstalls the current cloud including removing '
                         'of packages.')
     parser.add_argument('-c', '--config', type=str, dest='config_file',
                         help="Custom configuration for OpenStack installer.")
     parser.add_argument('-k', '--killcloud', action='store_true',
-                        dest='killcloud', default=False,
+                        dest='killcloud',
                         help='Tear down existing cloud leaving userdata '
                         'in place. Useful for iterative deploys.')
     parser.add_argument('--killcloud-noprompt', action='store_true',
-                        dest='killcloud_noprompt', default=False,
+                        dest='killcloud_noprompt',
                         help='Tear down existing cloud leaving userdata '
                         'in place. CAUTION: Does not confirm teardown, '
                         'Use with care!')
-    parser.add_argument('--openstack-release', default=None,
+    parser.add_argument('--openstack-release',
                         dest='openstack_release',
                         help="Specify a specific OpenStack release by "
                         "code-name, e.g. 'icehouse' or 'juno'")
@@ -81,7 +82,7 @@ def parse_options(argv):
                         'releases to filter available cloud images with '
                         'which to populate Glance, e.g. precise,trusty')
     parser.add_argument('-p', '--placement', action='store_true',
-                        dest='edit_placement', default=False,
+                        dest='edit_placement',
                         help='Show machine placement UI before deploying')
     parser.add_argument('--extra-ppa', nargs='+', dest='extra_ppa',
                         help='Append additional ppas to the single installers '
@@ -93,7 +94,7 @@ def parse_options(argv):
                         help='Specify HTTP proxy')
     parser.add_argument('--https-proxy', dest='https_proxy',
                         help='Specify HTTPS proxy')
-    parser.add_argument('--headless', action='store_true', default=False,
+    parser.add_argument('--headless', action='store_true',
                         help="Run deployment without prompts/gui",
                         dest='headless')
     parser.add_argument(

--- a/bin/openstack-status
+++ b/bin/openstack-status
@@ -25,8 +25,8 @@ from functools import partial
 
 # Handle imports where the path is not automatically updated during install.
 # This really only happens when a binary is not in the usual /usr/bin location
-# lib_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-# sys.path.insert(0, lib_dir)
+lib_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, lib_dir)
 
 from cloudinstall.gui import PegasusGUI
 from cloudinstall.core import Controller

--- a/bin/openstack-status
+++ b/bin/openstack-status
@@ -21,13 +21,12 @@ import logging
 import os
 import signal
 import sys
-import yaml
 from functools import partial
 
 # Handle imports where the path is not automatically updated during install.
 # This really only happens when a binary is not in the usual /usr/bin location
-lib_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, lib_dir)
+# lib_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+# sys.path.insert(0, lib_dir)
 
 from cloudinstall.gui import PegasusGUI
 from cloudinstall.core import Controller
@@ -46,7 +45,7 @@ for sig in (signal.SIGTERM, signal.SIGQUIT, signal.SIGINT, signal.SIGHUP):
     signal.signal(sig, sig_handler)
 
 
-def parse_options(*args, **kwds):
+def parse_options(argv):
     parser = argparse.ArgumentParser(description='Ubuntu Openstack Installer',
                                      prog='openstack-status')
     parser.add_argument('--placement', action='store_true',
@@ -59,29 +58,12 @@ def parse_options(*args, **kwds):
                         dest='headless')
     parser.add_argument(
         '--version', action='version', version='%(prog)s {}'.format(version))
-    return parser.parse_args()
-
-
-def populate_config(opts):
-    presaved_config = os.path.join(
-        utils.install_home(), '.cloud-install/config.yaml')
-
-    # Always override presaved config if defined in cli switch
-    if opts.config_file and os.path.exists(opts.config_file):
-        _cfg = yaml.load(utils.slurp(opts.config_file))
-    # Pull from ~/.cloud-install/config.yaml if exists
-    elif os.path.exists(presaved_config):
-        _cfg = yaml.load(utils.slurp(presaved_config))
-    else:
-        _cfg = {}
-    # Update cfg dict with command line opts
-    _cfg.update(vars(opts))
-    return Config(cfg_obj=_cfg)
+    return parser.parse_args(argv)
 
 
 if __name__ == '__main__':
-    opts = parse_options(sys.argv)
-    config = populate_config(opts)
+    opts = parse_options(sys.argv[1:])
+    config = Config(utils.populate_config(opts))
 
     try:
         log.setup_logger(headless=config.getopt('headless'))

--- a/bin/openstack-status
+++ b/bin/openstack-status
@@ -47,13 +47,14 @@ for sig in (signal.SIGTERM, signal.SIGQUIT, signal.SIGINT, signal.SIGHUP):
 
 def parse_options(argv):
     parser = argparse.ArgumentParser(description='Ubuntu Openstack Installer',
-                                     prog='openstack-status')
+                                     prog='openstack-status',
+                                     argument_default=argparse.SUPPRESS)
     parser.add_argument('--placement', action='store_true',
-                        dest='edit_placement', default=False,
+                        dest='edit_placement',
                         help='Show machine placement UI before deploying')
     parser.add_argument('-c', '--config', type=str, dest='config_file',
                         help="Custom configuration for OpenStack installer.")
-    parser.add_argument('--headless', action='store_true', default=False,
+    parser.add_argument('--headless', action='store_true',
                         help="Run deployment without prompts/gui",
                         dest='headless')
     parser.add_argument(

--- a/cloudinstall/config.py
+++ b/cloudinstall/config.py
@@ -162,7 +162,7 @@ class Config:
         if key in self._config:
             return self._config[key]
         else:
-            log.error("Could not find {} in config".format(key))
+            log.debug("Could not find {} in config".format(key))
             return False
 
     def juju_path(self):

--- a/cloudinstall/utils.py
+++ b/cloudinstall/utils.py
@@ -114,7 +114,7 @@ def populate_config(opts):
     def sanitize_config_items(_cfg):
         """ remove false and null items """
         return {k: v for (k, v) in _cfg.items()
-                if v is not None and v is not False}
+                if v is not None}
 
     if 'config_file' not in cfg_cli_opts:
         # Check for a pre-existing install config

--- a/test/files/good_config.yaml
+++ b/test/files/good_config.yaml
@@ -1,4 +1,7 @@
 install_type: single
+config_file: chittybang.yaml
+https_proxy: http://localhost:2222
+headless: true
 placements:
   fake_iid:
     constraints: 'mem=6G'

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -151,7 +151,6 @@ class TestGoodConfig(unittest.TestCase):
             parse_opts(['--http-proxy',
                         'http://localhost:2222',
                         '--config', cfg_file]))
-        print(cfg)
         self.assertEqual(cfg['https_proxy'], GOOD_CONFIG['https_proxy'])
 
     def test_default_opts_not_override_config(self):
@@ -173,7 +172,6 @@ class TestGoodConfig(unittest.TestCase):
         in the config object
         """
         cfg = utils.populate_config(parse_opts([]))
-        print(cfg)
         self.assertEqual(True, not cfg)
 
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -34,27 +34,27 @@ BAD_CONFIG = yaml.load(utils.slurp(path.join(DATA_DIR, 'bad_config.yaml')))
 
 
 def parse_opts(argv):
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS)
     parser.add_argument('-i', '--install-only', action='store_true',
-                        dest='install_only', default=False)
+                        dest='install_only')
     parser.add_argument('-u', '--uninstall', action='store_true',
-                        dest='uninstall', default=False)
+                        dest='uninstall')
     parser.add_argument('-c', '--config', type=str, dest='config_file')
     parser.add_argument('-k', '--killcloud', action='store_true',
-                        dest='killcloud', default=False)
+                        dest='killcloud')
     parser.add_argument('--killcloud-noprompt', action='store_true',
-                        dest='killcloud_noprompt', default=False)
+                        dest='killcloud_noprompt')
     parser.add_argument('--openstack-release', default=None,
                         dest='openstack_release')
     parser.add_argument('-a', type=str, default=None)
     parser.add_argument('-r', type=str, default=None, dest='release')
     parser.add_argument('-p', '--placement', action='store_true',
-                        dest='edit_placement', default=False)
+                        dest='edit_placement')
     parser.add_argument('--extra-ppa', nargs='+', dest='extra_ppa')
     parser.add_argument('--upstream-deb', dest='upstream_deb')
     parser.add_argument('--http-proxy', dest='http_proxy')
     parser.add_argument('--https-proxy', dest='https_proxy')
-    parser.add_argument('--headless', action='store_true', default=False,
+    parser.add_argument('--headless', action='store_true',
                         dest='headless')
     return parser.parse_args(argv)
 
@@ -161,7 +161,7 @@ class TestGoodConfig(unittest.TestCase):
         cfg_file = path.join(DATA_DIR, 'good_config.yaml')
         cfg_opts_raw = parse_opts(['--config', cfg_file])
         cfg_opts_raw = vars(cfg_opts_raw)
-        self.assertEqual(cfg_opts_raw['headless'], False)
+        self.assertEqual(True, 'headless' not in cfg_opts_raw)
 
         cfg = utils.populate_config(parse_opts(['--config', cfg_file]))
         self.assertEqual(True, cfg['headless'])
@@ -172,7 +172,7 @@ class TestGoodConfig(unittest.TestCase):
         in the config object
         """
         cfg = utils.populate_config(parse_opts([]))
-        self.assertEqual(True, not cfg)
+        self.assertEqual(True, 'headless' not in cfg)
 
 
 @unittest.skip

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -19,6 +19,7 @@ import logging
 import unittest
 import yaml
 import os.path as path
+import argparse
 from tempfile import NamedTemporaryFile
 
 from cloudinstall.config import Config
@@ -30,6 +31,32 @@ USER_DIR = path.expanduser('~')
 DATA_DIR = path.join(path.dirname(__file__), 'files')
 GOOD_CONFIG = yaml.load(utils.slurp(path.join(DATA_DIR, 'good_config.yaml')))
 BAD_CONFIG = yaml.load(utils.slurp(path.join(DATA_DIR, 'bad_config.yaml')))
+
+
+def parse_opts(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-i', '--install-only', action='store_true',
+                        dest='install_only', default=False)
+    parser.add_argument('-u', '--uninstall', action='store_true',
+                        dest='uninstall', default=False)
+    parser.add_argument('-c', '--config', type=str, dest='config_file')
+    parser.add_argument('-k', '--killcloud', action='store_true',
+                        dest='killcloud', default=False)
+    parser.add_argument('--killcloud-noprompt', action='store_true',
+                        dest='killcloud_noprompt', default=False)
+    parser.add_argument('--openstack-release', default=None,
+                        dest='openstack_release')
+    parser.add_argument('-a', type=str, default=None)
+    parser.add_argument('-r', type=str, default=None, dest='release')
+    parser.add_argument('-p', '--placement', action='store_true',
+                        dest='edit_placement', default=False)
+    parser.add_argument('--extra-ppa', nargs='+', dest='extra_ppa')
+    parser.add_argument('--upstream-deb', dest='upstream_deb')
+    parser.add_argument('--http-proxy', dest='http_proxy')
+    parser.add_argument('--https-proxy', dest='https_proxy')
+    parser.add_argument('--headless', action='store_true', default=False,
+                        dest='headless')
+    return parser.parse_args(argv)
 
 
 class TestGoodConfig(unittest.TestCase):
@@ -44,15 +71,15 @@ class TestGoodConfig(unittest.TestCase):
         """ Save openstack password to config """
         self.conf.setopt('openstack_password', 'pass')
         self.conf.save()
-        self.assertTrue('pass' in self.conf.getopt('openstack_password'))
+        self.assertEqual('pass', self.conf.getopt('openstack_password'))
 
     def test_save_maas_creds(self):
         """ Save maas credentials """
         self.conf.setopt('maascreds', dict(api_host='127.0.0.1',
                                            api_key='1234567'))
         self.conf.save()
-        self.assertTrue(
-            '127.0.0.1' in self.conf.getopt('maascreds')['api_host'])
+        self.assertEqual(
+            '127.0.0.1', self.conf.getopt('maascreds')['api_host'])
 
     def test_save_landscape_creds(self):
         """ Save landscape credentials """
@@ -63,29 +90,91 @@ class TestGoodConfig(unittest.TestCase):
                               maas_server='127.0.0.1',
                               maas_apikey='123457'))
         self.conf.save()
-        self.assertTrue(
-            'foo@bar.com' in self.conf.getopt('landscapecreds')['admin_email'])
+        self.assertEqual(
+            'foo@bar.com', self.conf.getopt('landscapecreds')['admin_email'])
 
     def test_save_installer_type(self):
         """ Save installer type """
         self.conf.setopt("install_type", 'multi')
         self.conf.save()
-        self.assertTrue('multi' in self.conf.getopt('install_type'))
+        self.assertEqual('multi', self.conf.getopt('install_type'))
 
     def test_cfg_path(self):
         """ Validate current users config path """
-        self.assertTrue(
-            self.conf.cfg_path == path.join(USER_DIR, '.cloud-install'))
+        self.assertEqual(
+            self.conf.cfg_path, path.join(USER_DIR, '.cloud-install'))
 
     def test_bin_path(self):
         """ Validate additional tools bin path """
-        self.assertTrue(self.conf.bin_path == '/usr/share/openstack/bin')
+        self.assertEqual(self.conf.bin_path, '/usr/share/openstack/bin')
 
     def test_juju_environments_path(self):
         """ Validate juju environments path in user dir """
-        self.assertTrue(
-            self.conf.juju_environments_path == path.join(
+        self.assertEqual(
+            self.conf.juju_environments_path,
+            path.join(
                 USER_DIR, '.cloud-install/juju/environments.yaml'))
+
+    def test_clear_empty_args(self):
+        """ Empty cli options are not populated
+        in generated config
+        """
+        cfg_file = path.join(DATA_DIR, 'good_config.yaml')
+        cfg = utils.populate_config(parse_opts(['--config', cfg_file]))
+        self.assertEqual(True, 'http-proxy' not in cfg)
+
+    def test_config_file_persists(self):
+        """ CLI options override options in config file
+        """
+        cfg_file = path.join(DATA_DIR, 'good_config.yaml')
+        cfg = utils.populate_config(
+            parse_opts(['--config', cfg_file,
+                        '--headless']))
+        self.assertEqual(True, cfg['headless'])
+
+    def test_config_file_persists_new_cli_opts(self):
+        """ Generated config object appends new options
+        passed via cli
+        """
+        cfg_file = path.join(DATA_DIR, 'good_config.yaml')
+        cfg = utils.populate_config(
+            parse_opts(['--config', cfg_file,
+                        '--install-only']))
+        self.assertEqual(True, cfg['install_only'])
+
+    def test_config_overrides_from_cli(self):
+        """ Config object item is not overridden
+        by unset cli option
+        """
+        cfg_file = path.join(DATA_DIR, 'good_config.yaml')
+        cfg = utils.populate_config(
+            parse_opts(['--http-proxy',
+                        'http://localhost:2222',
+                        '--config', cfg_file]))
+        print(cfg)
+        self.assertEqual(cfg['https_proxy'], GOOD_CONFIG['https_proxy'])
+
+    def test_default_opts_not_override_config(self):
+        """ Verify that default cli opts that are False
+        do not override their config_option whose option
+        is True.
+        """
+        cfg_file = path.join(DATA_DIR, 'good_config.yaml')
+        cfg_opts_raw = parse_opts(['--config', cfg_file])
+        cfg_opts_raw = vars(cfg_opts_raw)
+        self.assertEqual(cfg_opts_raw['headless'], False)
+
+        cfg = utils.populate_config(parse_opts(['--config', cfg_file]))
+        self.assertEqual(True, cfg['headless'])
+
+    def test_default_opts_no_config(self):
+        """ Verify that default cli opts are sanitized
+        and that no options set to False or None exist
+        in the config object
+        """
+        cfg = utils.populate_config(parse_opts([]))
+        print(cfg)
+        self.assertEqual(True, not cfg)
 
 
 @unittest.skip


### PR DESCRIPTION
Provides better logic for handling pulling config items from presaved configs, a config file passed into via `--config` and handles updating config object with items passed in via cli