### PR TITLE
Add -g for getting config values from openstack-install, then fix sync status listener

### DIFF
--- a/bin/openstack-install
+++ b/bin/openstack-install
@@ -61,6 +61,10 @@ def parse_options(argv):
                         help="Custom configuration for OpenStack installer.")
     parser.add_argument('--charm-config', type=str, dest='charm_config_file',
                         help="Additional charm settings")
+    parser.add_argument('-g', '--get-config', type=str, dest='get_config',
+                        default=None,
+                        help="with arg <key>, prints config value for 'key' "
+                        "to stdout and exits.")
     parser.add_argument('-k', '--killcloud', action='store_true',
                         dest='killcloud',
                         help='Tear down existing cloud leaving userdata '
@@ -107,6 +111,12 @@ def parse_options(argv):
 if __name__ == '__main__':
     opts = parse_options(sys.argv[1:])
     cfg = Config(utils.populate_config(opts))
+
+    if opts.get_config:
+        val = cfg.getopt(opts.get_config)
+        if val:
+            sys.stdout.write(val)
+        sys.exit(0)
 
     try:
         setup_logger(headless=cfg.getopt('headless'))

--- a/bin/status-listener
+++ b/bin/status-listener
@@ -18,7 +18,7 @@
 import kombu
 import logging
 import os
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, check_output
 import time
 import yaml
 
@@ -31,9 +31,14 @@ STATUS_FILE_NAME = os.path.join(CLOUD_INSTALL_DIR, "sync-status")
 def get_info():
     "Read rabbitmq config from remote unit's relation data"
 
+    juju_path = check_output('openstack-install -g juju_path',
+                             shell=True)
+    new_env = os.environ
+    new_env['JUJU_HOME'] = juju_path
     read_id_proc = Popen(['juju', 'run', '--unit',
                           'glance-simplestreams-sync/0',
                           'cat /etc/glance-simplestreams-sync/identity.yaml'],
+                         env=new_env,
                          stdout=PIPE, stderr=PIPE)
 
     (id_stdout, id_stderr) = read_id_proc.communicate()

--- a/cloudinstall/config.py
+++ b/cloudinstall/config.py
@@ -165,7 +165,6 @@ class Config:
             if hasattr(self, key):
                 attr = getattr(self, key)
                 return attr() if callable(attr) else attr
-            log.error("Could not find {} in config".format(key))
             return False
 
     def juju_path(self):

--- a/cloudinstall/config.py
+++ b/cloudinstall/config.py
@@ -162,6 +162,10 @@ class Config:
         if key in self._config:
             return self._config[key]
         else:
+            if hasattr(self, key):
+                attr = getattr(self, key)
+                return attr() if callable(attr) else attr
+            log.error("Could not find {} in config".format(key))
             return False
 
     def juju_path(self):
@@ -228,15 +232,3 @@ class Config:
     @property
     def juju_api_password(self):
         return self.juju_env['password']
-
-    def __getattr__(self, attr):
-        """ Protect us from invalid attribute lookup
-
-        TODO: Re-evaluate once config class is fully migrated
-        to getopt/setopt config scheme.
-        """
-        try:
-            getattr(Config, attr)
-        except AttributeError:
-            log.error("Unknown attribute: {}".format(attr))
-            return False


### PR DESCRIPTION
The sync status listener did not know about JUJU_HOME.

Added --get-config to openstack-install to let the listener (and other programs) read config values such as juju_path. -- this includes tweaks to Config.getopt() to account for some attributes being callable.