### PR TITLE
only create neutron network automatically if Single install

### DIFF
--- a/cloudinstall/charms/controller.py
+++ b/cloudinstall/charms/controller.py
@@ -69,7 +69,9 @@ class CharmNovaCloudController(CharmBase):
         err = utils.remote_run(
             unit.machine_id,
             cmds="/tmp/nova-controller-setup.sh "
-            "{p}".format(p=openstack_password),
+            "{p} {install_type}".format(
+                p=openstack_password,
+                install_type=self.config.getopt('install_type')),
             juju_home=self.config.juju_home(use_expansion=True))
         if err['status'] != 0:
             # something happened during nova setup, re-run

--- a/share/templates/nova-controller-setup.sh
+++ b/share/templates/nova-controller-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 . /tmp/openstack-admin-rc
 
@@ -26,19 +26,21 @@ keystone user-role-add --user ubuntu --role Member --tenant ubuntu
 
 . /tmp/openstack-ubuntu-rc
 
-# create vm network
-neutron net-create ubuntu-net
-neutron subnet-create --name ubuntu-subnet --gateway 10.0.5.1 --dns-nameserver 10.0.4.1 ubuntu-net 10.0.5.0/24
-neutron router-create ubuntu-router
-neutron router-interface-add ubuntu-router ubuntu-subnet
-neutron router-gateway-set ubuntu-router ext-net
+# create vm network on Single only
+if [ "$2" == "Single" ]; then
+  neutron net-create ubuntu-net
+  neutron subnet-create --name ubuntu-subnet --gateway 10.0.5.1 --dns-nameserver 10.0.4.1 ubuntu-net 10.0.5.0/24
+  neutron router-create ubuntu-router
+  neutron router-interface-add ubuntu-router ubuntu-subnet
+  neutron router-gateway-set ubuntu-router ext-net
 
-# create pool of floating ips
-i=0
-while [ $i -ne 5 ]; do
-	neutron floatingip-create ext-net
-	i=$((i + 1))
-done
+  # create pool of floating ips
+  i=0
+  while [ $i -ne 5 ]; do
+    neutron floatingip-create ext-net
+    i=$((i + 1))
+  done
+fi
 
 # configure security groups
 nova secgroup-add-rule default icmp -1 -1 0.0.0.0/0


### PR DESCRIPTION
With `multi` install path we'll require that 2 NICS be available and let the neutron charm configure itself automatically.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>