### PR TITLE
remove unnecessary ip route del args

### DIFF
--- a/tools/openstack-uninstall
+++ b/tools/openstack-uninstall
@@ -71,8 +71,7 @@ case $WHAT in
     echo Single install path.
     lxc-stop -n uoi-bootstrap || true
     lxc-destroy -n uoi-bootstrap || true
-    container_ip=$(openstack-install -g container_ip)
-    ip route del 10.0.4.0/24 via $container_ip dev lxcbr0 || true
+    ip route del 10.0.4.0/24 || true
     ;;
   *)
     echo Could not determine install type, was ~/.cloud-install removed prior to running the uninstallation?


### PR DESCRIPTION
this avoids being unnecessarily specific and deletes any route for the given prefix, assuming we set it up.
Otherwise, occasionally an install can get wedged because the new config has an IP that doesn't match the ip of the route we added previously.