### PR TITLE
Fix storage backend

### DIFF
--- a/bin/openstack-install
+++ b/bin/openstack-install
@@ -104,7 +104,8 @@ def parse_options(argv):
                         help="Run deployment without prompts/gui",
                         dest='headless')
     parser.add_argument('--storage', dest='storage_backend',
-                        choices=['ceph', 'swift'],
+                        default='none',
+                        choices=['ceph', 'swift', 'none'],
                         help="Choose storage backend to deploy initially.")
     # TODO: currently only works for single installs. Use
     # SHOW_JUJU_LOGS=1 in the env to enable. See github issue #421

--- a/cloudinstall/placement/controller.py
+++ b/cloudinstall/placement/controller.py
@@ -414,9 +414,12 @@ class PlacementController:
         elif selected_backend == 'ceph':
             # ceph-osd is never deployed initially, only included for
             # scale-out:
-            to_remove = swift_charms = ['ceph-osd']
+            to_remove = swift_charms + ['ceph-osd']
         elif selected_backend == 'swift':
             to_remove = ceph_charms
+        else:
+            raise AssertionError("unknown "
+                                 "backend '{}'".format(selected_backend))
 
         log.debug("to_remove is {}".format(to_remove))
 

--- a/cloudinstall/placement/controller.py
+++ b/cloudinstall/placement/controller.py
@@ -402,18 +402,21 @@ class PlacementController:
 
     def filter_storage_backends(self, charm_classes):
         "return list of charm classes with only selected backends"
-        all_backend_charms = ['swift-proxy', 'swift-storage',
-                              'ceph']
+        swift_charms = ['swift-proxy', 'swift-storage']
+        ceph_charms = ['ceph', 'ceph-osd', 'ceph-radosgw', 'cinder-ceph']
 
         selected_backend = self.config.getopt('storage_backend')
-        to_remove = all_backend_charms
+        log.debug("filtering storage charms. "
+                  " Selected backend is {}".format(selected_backend))
 
-        if selected_backend:
-            to_remove = [n for n in to_remove if
-                         selected_backend not in n]
-
-        # ceph-osd is never required, only included for scale-out:
-        to_remove.append('ceph-osd')
+        if selected_backend == 'none':
+            to_remove = swift_charms + ceph_charms
+        elif selected_backend == 'ceph':
+            # ceph-osd is never deployed initially, only included for
+            # scale-out:
+            to_remove = swift_charms = ['ceph-osd']
+        elif selected_backend == 'swift':
+            to_remove = ceph_charms
 
         log.debug("to_remove is {}".format(to_remove))
 

--- a/test/test_placement_controller.py
+++ b/test/test_placement_controller.py
@@ -397,6 +397,7 @@ class PlacementControllerTestCase(unittest.TestCase):
         mock_maas_state = MagicMock()
         mock_maas_state.machines.return_value = []
         c = Config()
+        c.setopt('storage_backend', 'none')
         pc = PlacementController(config=c, maas_state=mock_maas_state)
         pc.gen_defaults()
         mock_maas_state.machines.assert_called_with(MaasMachineStatus.READY)
@@ -415,6 +416,7 @@ class PlacementControllerTestCase(unittest.TestCase):
         pc = PlacementController(config=c)
 
         # default storage_backend is 'none'
+        c.setopt('storage_backend', 'none')
         defaults = pc.gen_single()
         self.assertFalse(find_charm(CharmSwiftProxy, defaults))
         self.assertFalse(find_charm(CharmSwift, defaults))


### PR DESCRIPTION
Ensure that storage_backend is always set, and add checks for cases where it might not be.

Also rework storage service filtering to take into account new charms and the case where no backend is selected.

Finally, fix tests that do not have a config set up by argparser.