### PR TITLE
Bring back error dialogs

### DIFF
--- a/cloudinstall/install.py
+++ b/cloudinstall/install.py
@@ -141,11 +141,15 @@ class InstallController:
         if self.config.getopt('headless'):
             log.info("Running in headless mode.")
             install_type = self.config.getopt('install_type')
-            if install_type:
-                self.do_install(install_type)
-            else:
+            if not install_type:
                 raise Exception(
                     'Unable to read install type from configuration.')
+            try:
+                self.do_install(install_type)
+            except:
+                log.exception("Fatal error")
+                self.loop.exit(1)
+
         else:
             self.ui.status_info_message("Get started by entering an OpenStack "
                                         "password for your cloud")


### PR DESCRIPTION
Changes from the addition of headless mode ended up hiding exceptions and breaking the error dialog box, resulting in timers running forever with no error indicator.

The issue is that calling self.loop.exit() ends up raising urwid.ExitMainLoop, which gets caught specifically in the urwid main loop and thus does not make it to our global exception handler, which is what generates the error dialog.

This fixes this in two ways:
1. It changes the headless code to catch and log all top level exceptions, and handles exiting cleanly there. This means that code in the Install classes does not have to worry about headless vs. regular, and can just raise exceptions and trust that whatever main loop is being used will do the right thing.
2. It changes a bunch of places in single_install where we were using loop.exit() to (in most cases) just let exceptions flow up without catching them. In some cases it raises exceptions explicitly for errors.

I tested this on a single install on cabeiri which was failing, and I tested both GUI and headless modes. GUI showed me a dialog, and headless logged the traceback and exited with returncode 1
