### PR TITLE
Makefile target tweak to permit installing only single-install package if desired

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ status:
 
 .PHONY: install
 install: ../openstack*.deb
-	-dpkg -i ../openstack*deb
+	-dpkg -i ../openstack_*deb
 	-dpkg -i ../openstack-${type}*deb
 	apt-get -yy install -f
 


### PR DESCRIPTION
Currently doing 'make type=single' still installs all packages. This is inconvenient when multi's deps are not desired (like maas).
This fix makes it so that type=single only installs single.