### PR TITLE
Check upstream deb sooner

### DIFF
--- a/cloudinstall/single_install.py
+++ b/cloudinstall/single_install.py
@@ -307,7 +307,6 @@ class SingleInstall:
     def do_install(self):
         self.display_controller.status_info_message("Building environment")
         if os.path.exists(self.container_abspath):
-            # Container exists, handle return code in installer
             raise Exception("Container exists, please uninstall or kill "
                             "existing cloud before proceeding.")
 
@@ -319,18 +318,14 @@ class SingleInstall:
 
         utils.ssh_genkey()
 
-        # Preparations
         self.prep_userdata()
 
-        # setup charm configurations
         utils.render_charm_config(self.config)
 
         self.prep_juju()
 
-        # Set permissions
         self.set_perms()
 
-        # Start container
         self.create_container_and_wait()
 
         # Copy over host ssh keys

--- a/cloudinstall/single_install.py
+++ b/cloudinstall/single_install.py
@@ -311,11 +311,13 @@ class SingleInstall:
             raise Exception("Container exists, please uninstall or kill "
                             "existing cloud before proceeding.")
 
-        try:
-            utils.ssh_genkey()
-        except:
-            log.exception("Error generating ssh key")
-            raise Exception("Error generating ssh key")
+        # check for deb early, will actually install it later
+        upstream_deb = self.config.getopt('upstream_deb')
+        if upstream_deb and not os.path.isfile(upstream_deb):
+                raise Exception("Upstream deb '{}' "
+                                "not found.".format(upstream_deb))
+
+        utils.ssh_genkey()
 
         # Preparations
         self.prep_userdata()
@@ -335,11 +337,9 @@ class SingleInstall:
         utils.container_cp(self.container_name,
                            os.path.join(utils.install_home(), '.ssh/id_rsa*'),
                            '.ssh/.')
+
         # Install local copy of openstack installer if provided
-        upstream_deb = self.config.getopt('upstream_deb')
         if upstream_deb:
-            if not os.path.isfile(upstream_deb):
-                raise Exception("Upstream deb specified but file not found.")
             shutil.copy(upstream_deb, self.config.cfg_path)
             self._install_upstream_deb()
 


### PR DESCRIPTION
1. moves check for upstream deb file to before any real time gets spent.
2. ssh_genkey doesn't need to have its exception rewrapped and printed twice 
3. remove some comments that don't say any more than the code they're next to
