### PR TITLE
Per-user container names

### DIFF
--- a/bin/openstack-install
+++ b/bin/openstack-install
@@ -173,6 +173,10 @@ if __name__ == '__main__':
         utils.chown(
             cfg.juju_path(), utils.install_user(), utils.install_user())
 
+    if not cfg.getopt('container_name'):
+        cfg.setopt('container_name',
+                   'openstack-single-{}'.format(utils.install_user()))
+
     if cfg.getopt('uninstall'):
         msg = ("Warning:\n\nThis will uninstall OpenStack and "
                "make a best effort to return the system back "
@@ -199,7 +203,7 @@ if __name__ == '__main__':
             if "y" in yn or "Y" in yn:
                 try:
                     print("Removing static route")
-                    ip = utils.container_ip('uoi-bootstrap')
+                    ip = utils.container_ip(cfg.getopt('container_name'))
                     out = utils.get_command_output(
                         'ip route del 10.0.4.0/24 via {} dev lxcbr0'.format(ip))
                     logger.debug("Removed route: {}".format(out['output']))
@@ -207,8 +211,8 @@ if __name__ == '__main__':
                     logger.exception("No static route defined.")
                     print("No static route defined.")
                 print("Removing host container...")
-                utils.container_stop('uoi-bootstrap')
-                utils.container_destroy('uoi-bootstrap')
+                utils.container_stop(cfg.getopt('container_name'))
+                utils.container_destroy(cfg.getopt('container_name'))
                 if os.path.isfile(os.path.join(cfg.cfg_path, 'installed')):
                     os.remove(os.path.join(cfg.cfg_path, 'installed'))
                 print("Container is removed.")

--- a/bin/openstack-status
+++ b/bin/openstack-status
@@ -89,9 +89,10 @@ if __name__ == '__main__':
     # Run openstack-status within container on single installs
     out = utils.get_command_output('hostname', user_sudo=True)
     hostname = out['output'].rstrip()
-    if config.is_single() and 'uoi-bootstrap' not in hostname:
+    if config.is_single() and config.getopt('container_name') not in hostname:
         logger.info("Running status within container")
-        utils.container_run_status('uoi-bootstrap', 'openstack-status', config)
+        utils.container_run_status(config.getopt('container_name'),
+                                   'openstack-status', config)
 
     if config.getopt('headless'):
         ui = ConsoleUI()

--- a/cloudinstall/single_install.py
+++ b/cloudinstall/single_install.py
@@ -36,7 +36,8 @@ class SingleInstall:
         self.config = config
         self.loop = loop
         self.tasker = self.display_controller.tasker(loop, config)
-        self.container_name = 'uoi-bootstrap'
+        username = utils.install_user()
+        self.container_name = 'openstack-single-{}'.format(username)
         self.container_path = '/var/lib/lxc'
         self.container_abspath = os.path.join(self.container_path,
                                               self.container_name)

--- a/docs/single-installer.guide.rst
+++ b/docs/single-installer.guide.rst
@@ -244,7 +244,9 @@ To do so run the following from the container host:
    $ sudo lxc-stop -n openstack-single-$USER
    $ sudo lxc-start -n openstack-single-$USER -d
    $ sudo lxc-attach -n openstack-single-$USER
-   # JUJU_HOME=~/.cloud-install/juju juju status
+   # now, inside the container:
+   % su ubuntu
+   % JUJU_HOME=~/.cloud-install/juju juju status
 
 From this point on it is a matter of waiting for all services to be restarted
 and shown as **agent-state: started** within the `juju status` output.

--- a/docs/single-installer.guide.rst
+++ b/docs/single-installer.guide.rst
@@ -241,10 +241,10 @@ To do so run the following from the container host:
 
 .. code::
 
-   $ sudo lxc-stop -n uoi-bootstrap
-   $ sudo lxc-start -n uoi-bootstrap -d
-   $ ssh ubuntu@ip-of-uoi-bootstrap-container
-   (uoi-bootstrap) $ JUJU_HOME=~/.cloud-install/juju juju status
+   $ sudo lxc-stop -n openstack-single-$USER
+   $ sudo lxc-start -n openstack-single-$USER -d
+   $ sudo lxc-attach -n openstack-single-$USER
+   # JUJU_HOME=~/.cloud-install/juju juju status
 
 From this point on it is a matter of waiting for all services to be restarted
 and shown as **agent-state: started** within the `juju status` output.

--- a/tools/openstack-uninstall
+++ b/tools/openstack-uninstall
@@ -3,6 +3,7 @@
 echo -n Ubuntu Openstack Installer Uninstalling ...
 
 WHAT=$(openstack-install -g install_type)
+CONTAINER_NAME=$(openstack-install -g container_name)
 
 if [ -f ~/.cloud-install/new-maas ]; then
   MAAS_TYPE=new
@@ -11,7 +12,7 @@ else
 fi
 
 apt_purge() {
-  DEBIAN_FRONTEND=noninteractive apt-get -yy purge $@
+  DEBIAN_FRONTEND=noninteractive apt-get -yy purnge $@
 }
 
 CFG_HOME=$(openstack-install -g cfg_path)
@@ -71,8 +72,8 @@ case $WHAT in
     ;;
   Single)
     echo Single install path.
-    lxc-stop -n uoi-bootstrap || true
-    lxc-destroy -n uoi-bootstrap || true
+    lxc-stop -n $CONTAINER_NAME || true
+    lxc-destroy -n $CONTAINER_NAME || true
     ip route del 10.0.4.0/24 || true
     ;;
   *)

--- a/tools/openstack-uninstall
+++ b/tools/openstack-uninstall
@@ -12,7 +12,7 @@ else
 fi
 
 apt_purge() {
-  DEBIAN_FRONTEND=noninteractive apt-get -yy purnge $@
+  DEBIAN_FRONTEND=noninteractive apt-get -yy purge $@
 }
 
 CFG_HOME=$(openstack-install -g cfg_path)


### PR DESCRIPTION
Simple support for different user accounts to have their own single-install container: just adds the username to the container name.