### PR TITLE
cap cpu count of VM created for controller node at 8

### DIFF
--- a/cloudinstall/placement/controller.py
+++ b/cloudinstall/placement/controller.py
@@ -436,7 +436,7 @@ class PlacementController:
 
         max_cpus = cpu_count()
         if max_cpus >= 2:
-            max_cpus = max_cpus // 2
+            max_cpus = min(8, max_cpus // 2)
 
         controller = PlaceholderMachine('controller', 'controller',
                                         {'mem': 6144,


### PR DESCRIPTION
fixes #343

the strategy suggested in #343's comments was good but we never found time to implement it, so just capping it at 8 seems like a reasonable fast solution