### PR TITLE
do not attempt to get lxc_network for multi install

### DIFF
--- a/cloudinstall/charms/controller.py
+++ b/cloudinstall/charms/controller.py
@@ -95,8 +95,13 @@ class CharmNovaCloudController(CharmBase):
 
     def render_setup_script(self):
         setup_template = utils.load_template("nova-controller-setup.sh")
-        lxc_network = self.config.getopt('lxc_network')
-        N = lxc_network.split('.')[2]
+        if self.config.is_single():
+            lxc_network = self.config.getopt('lxc_network')
+            N = lxc_network.split('.')[2]
+        else:
+            # N is used to define networks for single, so we simply
+            # set a dummy value for multi
+            N = 0
 
         setup_script_path = os.path.join(self.config.cfg_path,
                                          "nova-controller-setup.sh")

--- a/test/test_charm_controller.py
+++ b/test/test_charm_controller.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+#
+# Copyright 2015 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from jinja2 import Environment, FileSystemLoader
+import logging
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+from cloudinstall.charms.controller import CharmNovaCloudController
+
+log = logging.getLogger('cloudinstall.test_charms')
+
+
+def source_tree_template_loader(name):
+    p = os.path.join(os.path.dirname(__file__), "../share/templates")
+    return Environment(loader=FileSystemLoader(p)).get_template(name)
+
+
+class TestController(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_jujuclient = MagicMock(name='jujuclient')
+        self.mock_juju_state = MagicMock(name='juju_state')
+        self.mock_ui = MagicMock(name='ui')
+        self.mock_config = MagicMock(name='config')
+
+        self.get_config_patcher = patch('cloudinstall.charms.get_charm_config')
+        self.mock_get_config = self.get_config_patcher.start()
+        self.mock_get_config.return_value = ({}, None)
+
+        self.charm = CharmNovaCloudController(juju=self.mock_jujuclient,
+                                              juju_state=self.mock_juju_state,
+                                              ui=self.mock_ui,
+                                              config=self.mock_config)
+        self.ltp = patch('cloudinstall.utils.load_template')
+        self.mock_load_template = self.ltp.start()
+        self.mock_load_template.side_effect = source_tree_template_loader
+
+    def tearDown(self):
+        self.get_config_patcher.stop()
+        self.ltp.stop()
+
+    @patch('cloudinstall.utils.spew')
+    def test_render_setup_script_single(self, mock_spew):
+        self.mock_config.is_single.return_value = True
+        self.mock_config.cfg_path = 'fake-cfg-path'
+        self.mock_config.getopt.return_value = '10.0.90210.0/24'
+        self.charm.render_setup_script()
+        name, (path, script_text), kwargs = mock_spew.mock_calls[0]
+        self.mock_config.getopt.assert_called_with('lxc_network')
+        self.assertEqual(path, 'fake-cfg-path/nova-controller-setup.sh')
+        self.assertTrue('--gateway 10.0.90210.1' in script_text)
+
+    @patch('cloudinstall.utils.spew')
+    def test_render_setup_script_multi(self, mock_spew):
+        self.mock_config.is_single.return_value = False
+        self.mock_config.cfg_path = 'fake-cfg-path'
+
+        self.charm.render_setup_script()
+        name, (path, script_text), kwargs = mock_spew.mock_calls[0]
+        self.assertFalse(self.mock_config.getopt.called)
+        self.assertEqual(path, 'fake-cfg-path/nova-controller-setup.sh')
+        self.assertTrue('--gateway 10.0.0.1' in script_text)


### PR DESCRIPTION
we now render the network setup script as a template, but multi installs don't have a meaningful 'lxc_network' config-- getopt will return False and fail as in #497 .

This uses a dummy '0' value for multi installs, which is OK because the script doesn't set up networks for multi anyway.

It also adds tests for the changed function in charms/controller.py