### PR TITLE
re-enable contrib charms now that placement has CharmState

### DIFF
--- a/cloudinstall/placement/controller.py
+++ b/cloudinstall/placement/controller.py
@@ -168,8 +168,7 @@ class PlacementController:
     def charm_classes(self):
         cl = [m.__charm_class__ for m in
               load_charms(self.config.getopt('charm_plugin_dir'))
-              if not m.__charm_class__.disabled and not
-              m.__charm_class__.contrib]
+              if not m.__charm_class__.disabled]
 
         return cl
 


### PR DESCRIPTION
now that the placement code is smarter about determining which charms to place by default, we can re-enable the contrib charms to allow them to be added in the placement UI