### PR TITLE
Wait for services to start

### DIFF
--- a/cloudinstall/charms/__init__.py
+++ b/cloudinstall/charms/__init__.py
@@ -261,45 +261,6 @@ export OS_REGION_NAME=RegionOne
         """
         pass
 
-    def wait_for_agent(self, svcs=None):
-        """ Waits for service agent to be reachable
-
-        :param list svcs: List of services to check or empty for calling
-                          service
-        :rtype: :class:`~cloudinstall.service.Unit`
-        :returns: True if all svcs are started, False otherwise
-        """
-        status_res = []
-        prev_state = None
-
-        def format_agent_status(name, state, prev_state):
-            self.ui.status_info_message(
-                "Checking availability of {0}: {1} "
-                "(previous_state: {})".format(
-                    name, state, prev_state))
-            prev_state = unit.agent_state
-
-        if not svcs:
-            svcs = [self.charm_name]
-
-        for svc_name in svcs:
-            svc = self.juju_state.service(svc_name)
-            log.debug("Checking availability for {c}: {s}.".format(
-                c=svc_name,
-                s=svc))
-            try:
-                unit = svc.unit(svc_name)
-                if unit.agent_state == "started":
-                    status_res.append(True)
-                    continue
-                if prev_state != unit.agent_state:
-                    format_agent_status(svc_name, unit.agent_state,
-                                        prev_state)
-                status_res.append(False)
-            except:
-                return False
-        return all(status_res)
-
     def __repr__(self):
         return self.name()
 

--- a/cloudinstall/charms/controller.py
+++ b/cloudinstall/charms/controller.py
@@ -43,8 +43,6 @@ class CharmNovaCloudController(CharmBase):
 
     def post_proc(self):
         """ post processing for nova-cloud-controller """
-        if not self.wait_for_agent(['keystone', self.charm_name]):
-            return True
         svc = self.juju_state.service(self.charm_name)
         unit = svc.unit(self.charm_name)
         k_svc = self.juju_state.service('keystone')

--- a/cloudinstall/charms/glance_simplestreams_sync.py
+++ b/cloudinstall/charms/glance_simplestreams_sync.py
@@ -85,13 +85,6 @@ class CharmGlanceSimplestreamsSync(CharmBase):
     def deploy(self, mspec):
         """Temporary override to get local copy of charm."""
 
-        # FIXME: This shouldnt be needed as the charm should
-        # handle any relation processing against keystone/swift
-        # no matter the state of those services.
-        wait_on = ['keystone', 'rabbitmq-server']
-        if not self.wait_for_agent(wait_on):
-            return True
-
         log.debug("downloading stable branch from github")
         try:
             self.download_stable()

--- a/cloudinstall/charms/keystone.py
+++ b/cloudinstall/charms/keystone.py
@@ -33,14 +33,6 @@ class CharmKeystone(CharmBase):
     menuable = True
     is_core = True
 
-    def deploy(self, m):
-        mysql_exists = self.wait_for_agent(['mysql'])
-        if not mysql_exists:
-            log.debug("mysql not yet available, deferring keystone deploy")
-            return True
-        log.debug("mysql is available, deploying keystone")
-        return super().deploy(m)
-
     def _is_auth_url_valid(self):
         existing_yaml = yaml.load(slurp(self.config.juju_environments_path))
         existing_yaml = existing_yaml['environments']
@@ -57,9 +49,6 @@ class CharmKeystone(CharmBase):
         if self._is_auth_url_valid():
             return False
 
-        keystone = self.wait_for_agent()
-        if not keystone:
-            return True
         service = self.juju_state.service('keystone')
         if len(service.units) > 0:
             unit = service.units[0]

--- a/cloudinstall/charms/quantum.py
+++ b/cloudinstall/charms/quantum.py
@@ -47,8 +47,6 @@ class CharmQuantum(CharmBase):
 
     def post_proc(self):
         """ performs additional network configuration for charm """
-        if not self.wait_for_agent([self.charm_name, 'nova-cloud-controller']):
-            return True
         svc = self.juju_state.service(self.charm_name)
         unit = svc.unit(self.charm_name)
 

--- a/cloudinstall/consoleui.py
+++ b/cloudinstall/consoleui.py
@@ -40,8 +40,9 @@ class ConsoleUI:
         log.info(msg)
 
     def set_pending_deploys(self, names):
-        names = ", ".join(names)
-        log.info("Charms set to deploy: {}".format(names))
+        if len(names) > 0:
+            names = ", ".join(names)
+            log.info("Pending charms to deploy: {}".format(names))
 
     def __getattr__(self, attr):
         """

--- a/cloudinstall/core.py
+++ b/cloudinstall/core.py
@@ -539,6 +539,9 @@ class Controller:
         """ Blocks until all deployed services attached units
         are in a 'started' state
         """
+        if not self.juju_state:
+            return
+
         not_ready_len = 0
         while not self.juju_state.all_agents_started():
             not_ready = [(a, b) for a, b in self.juju_state.get_agent_states()

--- a/cloudinstall/core.py
+++ b/cloudinstall/core.py
@@ -277,8 +277,7 @@ class Controller:
             self.set_unique_hostnames()
 
         self.deploy_using_placement()
-        self.ui.status_info_message(
-            "Waiting for deployed services to be in a ready state.")
+        self.wait_for_deployed_services_ready()
         self.enqueue_deployed_charms()
 
     def set_unique_hostnames(self):
@@ -542,6 +541,9 @@ class Controller:
         if not self.juju_state:
             return
 
+        self.ui.status_info_message(
+            "Waiting for deployed services to be in a ready state.")
+
         not_ready_len = 0
         while not self.juju_state.all_agents_started():
             not_ready = [(a, b) for a, b in self.juju_state.get_agent_states()
@@ -562,9 +564,6 @@ class Controller:
         """Send all deployed charms to CharmQueue for relation setting and
         post-proc.
         """
-
-        self.wait_for_deployed_services_ready()
-
         charm_q = CharmQueue(ui=self.ui, config=self.config,
                              juju=self.juju, juju_state=self.juju_state,
                              deployed_charms=self.deployed_charm_classes)

--- a/cloudinstall/core.py
+++ b/cloudinstall/core.py
@@ -277,6 +277,8 @@ class Controller:
             self.set_unique_hostnames()
 
         self.deploy_using_placement()
+        self.ui.status_info_message(
+            "Waiting for deployed services to be in a ready state.")
         self.enqueue_deployed_charms()
 
     def set_unique_hostnames(self):
@@ -537,12 +539,9 @@ class Controller:
         """ Blocks until all deployed services attached units
         are in a 'started' state
         """
-        self.ui.status_info_message(
-            "Waiting for deployed services to be in a ready state.")
-
         not_ready_len = 0
         while not self.juju_state.all_agents_started():
-            not_ready = [(a, b) for a, b in self.juju_state.get_agents_states()
+            not_ready = [(a, b) for a, b in self.juju_state.get_agent_states()
                          if b != 'started']
             if len(not_ready) == not_ready_len:
                 time.sleep(3)

--- a/cloudinstall/juju.py
+++ b/cloudinstall/juju.py
@@ -40,6 +40,31 @@ class JujuState:
         self._juju_status = None
         self.valid_states = ['pending', 'started', 'down']
 
+    def get_agents_states(self):
+        """ Returns list of deployed services and their agent-state """
+        states = []
+        for svc in self.services:
+            for unit in svc.units:
+                states.append((svc.service_name, unit.agent_state))
+        return states
+
+    def all_agents_started(self):
+        """ Check status of all deployed agents
+
+        :param list svcs: List of services to check or empty for calling
+                          service
+        :rtype: :class:`~cloudinstall.service.Unit`
+        :returns: True if all svcs are started, False otherwise
+        """
+        status_res = []
+        for svc, state in self.get_agents_states():
+            if state == "started":
+                status_res.append(True)
+                continue
+            else:
+                return False
+        return all(status_res)
+
     def status(self):
         """Returns juju status.
         Caches value for 20 seconds.

--- a/cloudinstall/juju.py
+++ b/cloudinstall/juju.py
@@ -56,14 +56,8 @@ class JujuState:
         :rtype: :class:`~cloudinstall.service.Unit`
         :returns: True if all svcs are started, False otherwise
         """
-        status_res = []
-        for svc, state in self.get_agent_states():
-            if state == "started":
-                status_res.append(True)
-                continue
-            else:
-                return False
-        return all(status_res)
+        return all([state == "started" for _, state in
+                    self.get_agent_states()])
 
     def status(self):
         """Returns juju status.

--- a/cloudinstall/juju.py
+++ b/cloudinstall/juju.py
@@ -40,7 +40,7 @@ class JujuState:
         self._juju_status = None
         self.valid_states = ['pending', 'started', 'down']
 
-    def get_agents_states(self):
+    def get_agent_states(self):
         """ Returns list of deployed services and their agent-state """
         states = []
         for svc in self.services:
@@ -57,7 +57,7 @@ class JujuState:
         :returns: True if all svcs are started, False otherwise
         """
         status_res = []
-        for svc, state in self.get_agents_states():
+        for svc, state in self.get_agent_states():
             if state == "started":
                 status_res.append(True)
                 continue

--- a/cloudinstall/service.py
+++ b/cloudinstall/service.py
@@ -110,9 +110,10 @@ class Unit:
         return 'nova-cloud-controller' in self.unit_name
 
     def __repr__(self):
-        return "<Unit: {name} " \
-            "Machine: {machine}>".format(name=self.unit_name,
-                                         machine=self.machine_id)
+        return "<Unit: {name}, Machine: {machine}, State: {state}>".format(
+            name=self.unit_name,
+            machine=self.machine_id,
+            state=self.agent_state)
 
 
 class Relation:

--- a/test/test_charms.py
+++ b/test/test_charms.py
@@ -90,16 +90,6 @@ class PrepCharmTest(unittest.TestCase):
                 config=self.mock_config)
 
 
-class TestCharmKeystone(PrepCharmTest):
-
-    def test_missing_agent_state(self):
-        """ Checks deploy returns False if agent_state is None/missing """
-        ms = MagicMock(name='mock_server')
-        self.mock_juju_state.service.return_value = ms
-        rv = self.charm.wait_for_agent(['mysql'])
-        self.assertFalse(rv)
-
-
 class TestCharmRelations(unittest.TestCase):
 
     """ Use NovaCompute to determine if certain relations

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+#
+# Copyright 2015 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import unittest
+from unittest.mock import MagicMock, PropertyMock
+
+from cloudinstall.config import Config
+from cloudinstall.core import Controller
+from cloudinstall.juju import JujuState
+from cloudinstall.service import Service
+
+log = logging.getLogger('cloudinstall.test_core')
+
+
+class EnqueueDeployedCoreTestCase(unittest.TestCase):
+
+    """ Tests core.enqueue_deployed_charms() to make sure waiting
+    for services to start are handled properly.
+    """
+
+    def setUp(self):
+        self.conf = Config({})
+        self.mock_ui = MagicMock(name='ui')
+        self.mock_log = MagicMock(name='log')
+        self.mock_loop = MagicMock(name='loop')
+
+        self.services_ready = [
+            Service('keystone',
+                    {'Units': {'fake': {'AgentState': 'started'}}}),
+            Service('nova-compute',
+                    {'Units': {'fake': {'AgentState': 'started'}}}),
+        ]
+
+        self.services_some_ready = [
+            Service('keystone',
+                    {'Units': {'fake': {'AgentState': 'started'}}}),
+            Service('nova-compute',
+                    {'Units': {'fake2': {'AgentState': 'started'}}}),
+            Service('nova-cloud-controller',
+                    {'Units': {'fake3': {'AgentState': 'installing'}}}),
+            Service('glance',
+                    {'Units': {'fake4': {'AgentState': 'allocating'}}}),
+        ]
+
+    def test_validate_services_ready(self):
+        """ Verifies services ready allow enqueue to complete
+        to end of its routine """
+        self.conf.setopt('headless', False)
+        dc = Controller(
+            ui=self.mock_ui, config=self.conf,
+            loop=self.mock_loop)
+        dc.initialize = MagicMock()
+        dc.juju_state = JujuState(juju=MagicMock())
+        dc.juju_state.all_agents_started = MagicMock()
+        dc.juju_state.all_agents_started.return_value = all(
+            self.services_ready)
+
+        dc.enqueue_deployed_charms()
+        self.mock_loop.redraw_screen.assert_called_once_with()
+
+    def test_services_ready(self):
+        """ Verifies all ready services  """
+        juju_state = JujuState(juju=MagicMock())
+        services = PropertyMock(return_value=self.services_ready)
+        type(juju_state).services = services
+        self.assertTrue(juju_state.all_agents_started())
+
+    def test_some_services_ready(self):
+        """ Verifies some ready services == not_ready list """
+        juju_state = JujuState(juju=MagicMock())
+        services = PropertyMock(return_value=self.services_some_ready)
+        type(juju_state).services = services
+        not_ready = [(a, b) for a, b in juju_state.get_agents_states()
+                     if b != 'started']
+        self.assertEqual(len(not_ready), 2)

--- a/test/test_ev.py
+++ b/test/test_ev.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -67,6 +67,7 @@ class EventLoopCoreTestCase(unittest.TestCase):
             ui=self.mock_ui, config=self.conf,
             loop=self.mock_loop)
         dc.initialize = MagicMock()
+        dc.juju_state = MagicMock()
         dc.enqueue_deployed_charms()
         self.mock_loop.redraw_screen.assert_called_once_with()
 

--- a/test/test_ev.py
+++ b/test/test_ev.py
@@ -67,7 +67,6 @@ class EventLoopCoreTestCase(unittest.TestCase):
             ui=self.mock_ui, config=self.conf,
             loop=self.mock_loop)
         dc.initialize = MagicMock()
-        dc.juju_state = MagicMock()
         dc.enqueue_deployed_charms()
         self.mock_loop.redraw_screen.assert_called_once_with()
 

--- a/test/test_juju_state.py
+++ b/test/test_juju_state.py
@@ -67,6 +67,6 @@ class JujuStateTestCase(unittest.TestCase):
         juju_state = JujuState(juju=MagicMock())
         services = PropertyMock(return_value=self.services_some_ready)
         type(juju_state).services = services
-        not_ready = [(a, b) for a, b in juju_state.get_agents_states()
+        not_ready = [(a, b) for a, b in juju_state.get_agent_states()
                      if b != 'started']
         self.assertEqual(len(not_ready), 2)

--- a/test/test_juju_state.py
+++ b/test/test_juju_state.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+#
+# Copyright 2015 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import unittest
+from unittest.mock import MagicMock, PropertyMock
+
+from cloudinstall.config import Config
+from cloudinstall.juju import JujuState
+from cloudinstall.service import Service
+
+log = logging.getLogger('cloudinstall.test_core')
+
+
+class JujuStateTestCase(unittest.TestCase):
+
+    """ Tests JujuState's services ready routines
+    """
+
+    def setUp(self):
+        self.conf = Config({})
+        self.mock_ui = MagicMock(name='ui')
+        self.mock_log = MagicMock(name='log')
+        self.mock_loop = MagicMock(name='loop')
+
+        self.services_ready = [
+            Service('keystone',
+                    {'Units': {'fake': {'AgentState': 'started'}}}),
+            Service('nova-compute',
+                    {'Units': {'fake': {'AgentState': 'started'}}}),
+        ]
+
+        self.services_some_ready = [
+            Service('keystone',
+                    {'Units': {'fake': {'AgentState': 'started'}}}),
+            Service('nova-compute',
+                    {'Units': {'fake2': {'AgentState': 'started'}}}),
+            Service('nova-cloud-controller',
+                    {'Units': {'fake3': {'AgentState': 'installing'}}}),
+            Service('glance',
+                    {'Units': {'fake4': {'AgentState': 'allocating'}}}),
+        ]
+
+    def test_services_ready(self):
+        """ Verifies all ready services  """
+        juju_state = JujuState(juju=MagicMock())
+        services = PropertyMock(return_value=self.services_ready)
+        type(juju_state).services = services
+        self.assertTrue(juju_state.all_agents_started())
+
+    def test_some_services_ready(self):
+        """ Verifies some ready services == not_ready list """
+        juju_state = JujuState(juju=MagicMock())
+        services = PropertyMock(return_value=self.services_some_ready)
+        type(juju_state).services = services
+        not_ready = [(a, b) for a, b in juju_state.get_agents_states()
+                     if b != 'started']
+        self.assertEqual(len(not_ready), 2)

--- a/test/test_juju_state.py
+++ b/test/test_juju_state.py
@@ -60,7 +60,11 @@ class JujuStateTestCase(unittest.TestCase):
         juju_state = JujuState(juju=MagicMock())
         services = PropertyMock(return_value=self.services_ready)
         type(juju_state).services = services
-        self.assertTrue(juju_state.all_agents_started())
+
+        not_ready = [(a, b) for a, b in juju_state.get_agent_states()
+                     if b != 'started']
+
+        self.assertEqual(len(not_ready), 0)
 
     def test_some_services_ready(self):
         """ Verifies some ready services == not_ready list """
@@ -70,3 +74,4 @@ class JujuStateTestCase(unittest.TestCase):
         not_ready = [(a, b) for a, b in juju_state.get_agent_states()
                      if b != 'started']
         self.assertEqual(len(not_ready), 2)
+        self.assertFalse(juju_state.all_agents_started())


### PR DESCRIPTION
Refactored how we are waiting for services to start before
relations/post processing are being handled.

Removed the needs to override set_relations() in charms in order
to define additional wait checks as this is handled automatically.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>