### PR TITLE
Show deps and conflicts in placement ui, disallow placing conflicting charms

### DIFF
--- a/cloudinstall/placement/controller.py
+++ b/cloudinstall/placement/controller.py
@@ -275,8 +275,8 @@ class PlacementController:
 
         """
         state = CharmState.OPTIONAL
-        conflicting = []
-        depending = []
+        conflicting = set()
+        depending = set()
 
         def conflicts_with(other_charm):
             return (charm.charm_name in other_charm.conflicts or
@@ -293,11 +293,11 @@ class PlacementController:
         for other_charm in placed_or_required:
             if conflicts_with(other_charm):
                 state = CharmState.CONFLICTED
-                conflicting.append(other_charm)
+                conflicting.add(other_charm)
             if depends(other_charm, charm):
                 if state != CharmState.CONFLICTED:
                     state = CharmState.REQUIRED
-                depending.append(other_charm)
+                depending.add(other_charm)
 
         if charm in required_charms:
             state = CharmState.REQUIRED
@@ -317,7 +317,7 @@ class PlacementController:
         elif state == CharmState.REQUIRED and n_units >= n_required:
             state = CharmState.OPTIONAL
 
-        return (state, conflicting, depending)
+        return (state, list(conflicting), list(depending))
 
     def can_deploy(self):
         unplaced_requireds = [cc for cc in self.unplaced_services

--- a/cloudinstall/placement/ui.py
+++ b/cloudinstall/placement/ui.py
@@ -715,7 +715,11 @@ class ServicesColumn(WidgetWrap):
                                       self.placement_controller,
                                       self.placement_view)
 
-        actions = [("Choose Machine",
+        def not_conflicted_p(cc):
+            state, _, _ = self.placement_controller.get_charm_state(cc)
+            return state != CharmState.CONFLICTED
+
+        actions = [(not_conflicted_p, "Choose Machine",
                     self.placement_view.do_show_machine_chooser)]
         self.required_services_list = ServicesList(self.placement_controller,
                                                    actions,


### PR DESCRIPTION
Shows conflicted status of charms.
Here's a screenshot with all required charms placed and no conflicts:
![1-no-storage-no-conflicts](https://cloud.githubusercontent.com/assets/1768106/6848752/50b48f84-d38c-11e4-94bd-aca44b49b481.png)

Here's a screenshot where we placed swift, so now ceph-radosgw is blocked due to conflict, and the button is disabled. If you remove swift, ceph-radosgw will be unblocked:
![2-swift-placed-shows-cons](https://cloud.githubusercontent.com/assets/1768106/6848753/50b52656-d38c-11e4-9fd5-612ca6c7c536.png)

Now here's a screenshot where we placed Ceph-OSD and Swift-Proxy, so now Ceph is required due to a Ceph-OSD->Ceph dep, and swift is required due to swift-proxy->swift dep, so those deps are shown to explain the newly required charms. Also ceph-radosgw is blocked again, that's shown here too:

![3-shows-cons-and-deps](https://cloud.githubusercontent.com/assets/1768106/6848754/50b5baee-d38c-11e4-8dbf-8b6daaa0840a.png)


