### PR TITLE
Handle subordinate charms correctly in placement UI

### DIFF
--- a/cloudinstall/placement/controller.py
+++ b/cloudinstall/placement/controller.py
@@ -174,17 +174,30 @@ class PlacementController:
         self.reset_unplaced()
         self.save()
 
-    def machines(self):
+    def machines(self, include_placeholders=True):
+        """Returns all machines known to the controller.
+
+        if 'include_placeholder' is False, any placeholder machines
+        are excluded.
+        """
         if self.maas_state:
             ms = self.maas_state.machines()
         else:
             ms = self._machines
 
-        return ms + [self.sub_placeholder]
+        if include_placeholders:
+            return ms + [self.sub_placeholder]
+        else:
+            return ms
 
-    def machines_used(self):
+    def machines_used(self, include_placeholders=False):
+        """Returns a list of machines that have charms placed on them.
+
+        Excludes placeholder machines by default, so this can be used
+        to e.g. get the number of real machines to wait for.
+        """
         ms = []
-        for m in self.machines():
+        for m in self.machines(include_placeholders=include_placeholders):
             if m.instance_id in self.assignments:
                 n = sum(len(cl) for _, cl in
                         self.assignments[m.instance_id].items())

--- a/cloudinstall/placement/ui/machine_widget.py
+++ b/cloudinstall/placement/ui/machine_widget.py
@@ -97,11 +97,14 @@ class MachineWidget(WidgetWrap):
 
     def update(self):
         self.update_machine()
-        info_markup = ["\N{TAPE DRIVE} {}".format(self.machine.hostname),
-                       ('label', " ({})".format(self.machine.status))]
-
-        self.machine_info_widget.set_text(info_markup)
-        self.hardware_widget.set_text(["  "] + self.hardware_info_markup())
+        if self.machine == self.controller.sub_placeholder:
+            self.machine_info_widget.set_text("\N{BULLET} Subordinate Charms")
+            self.hardware_widget.set_text("")
+        else:
+            info_markup = ["\N{TAPE DRIVE} {}".format(self.machine.hostname),
+                           ('label', " ({})".format(self.machine.status))]
+            self.machine_info_widget.set_text(info_markup)
+            self.hardware_widget.set_text(["  "] + self.hardware_info_markup())
 
         ad = self.controller.assignments_for_machine(self.machine)
         astr = [('label', "  Services: ")]
@@ -124,7 +127,16 @@ class MachineWidget(WidgetWrap):
                 astr.append(", ".join(["\N{GEAR} {}".format(c.display_name)
                                        for c in al]))
 
-        self.assignments_widget.set_text(astr)
+        if self.machine == self.controller.sub_placeholder:
+            assignments_text = ''
+            for _, al in ad.items():
+                charm_txts = ["\N{GEAR} {}".format(c.display_name)
+                              for c in al]
+                assignments_text += ", ".join(charm_txts)
+        else:
+            assignments_text = astr
+
+        self.assignments_widget.set_text(assignments_text)
         self.update_buttons()
 
     def update_buttons(self):

--- a/cloudinstall/placement/ui/machines_list.py
+++ b/cloudinstall/placement/ui/machines_list.py
@@ -13,13 +13,15 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
+import logging
 from urwid import (AttrMap, Divider, Padding, Pile, Text, WidgetWrap)
 
 from cloudinstall.maas import satisfies
 
 from cloudinstall.placement.ui.filter_box import FilterBox
 from cloudinstall.placement.ui.machine_widget import MachineWidget
+
+log = logging.getLogger('cloudinstall.placement')
 
 
 class MachinesList(WidgetWrap):

--- a/cloudinstall/placement/ui/service_chooser.py
+++ b/cloudinstall/placement/ui/service_chooser.py
@@ -54,9 +54,10 @@ class ServiceChooser(WidgetWrap):
                     return True
             return False
 
+        actions = [(show_remove_p, 'Remove', self.do_remove)]
+
         self.services_list = ServicesList(self.controller,
-                                          [(show_remove_p, 'Remove',
-                                            self.do_remove)],
+                                          actions, actions,
                                           machine=self.machine)
 
         close_button = AttrMap(Button('X',

--- a/cloudinstall/placement/ui/service_widget.py
+++ b/cloudinstall/placement/ui/service_widget.py
@@ -68,7 +68,9 @@ class ServiceWidget(WidgetWrap):
         self.charm_info_widget = Text(self.title_markup)
         self.assignments_widget = Text("")
 
-        if len(self.charm_class.constraints) == 0:
+        if self.charm_class.subordinate:
+            c_str = [('label', "  (subordinate charm)")]
+        elif len(self.charm_class.constraints) == 0:
             c_str = [('label', "  no constraints set")]
         else:
             cpairs = [format_constraint(k, v) for k, v in

--- a/cloudinstall/placement/ui/services_list.py
+++ b/cloudinstall/placement/ui/services_list.py
@@ -36,12 +36,12 @@ class ServicesList(WidgetWrap):
 
     """
 
-    def __init__(self, controller, actions, machine=None,
-                 unplaced_only=False, show_type='all',
-                 show_constraints=False,
-                 title="Services"):
+    def __init__(self, controller, actions, subordinate_actions,
+                 machine=None, unplaced_only=False, show_type='all',
+                 show_constraints=False, title="Services"):
         self.controller = controller
         self.actions = actions
+        self.subordinate_actions = subordinate_actions
         self.service_widgets = []
         self.machine = machine
         self.unplaced_only = unplaced_only
@@ -104,7 +104,11 @@ class ServicesList(WidgetWrap):
             sw.update()
 
     def add_service_widget(self, charm_class):
-        sw = ServiceWidget(charm_class, self.controller, self.actions,
+        if charm_class.subordinate:
+            actions = self.subordinate_actions
+        else:
+            actions = self.actions
+        sw = ServiceWidget(charm_class, self.controller, actions,
                            self.show_constraints)
         self.service_widgets.append(sw)
         options = self.service_pile.options()

--- a/test/test_placement_ui.py
+++ b/test/test_placement_ui.py
@@ -274,12 +274,11 @@ class MachinesListTestCase(unittest.TestCase):
                 MachinesList(self.pc, self.actions,
                              show_hardware=show_hardware,
                              show_assignments=show_assignments)
-                mock_machinewidget.assert_called_with(
-                    self.mock_machine,
-                    self.pc,
-                    self.actions,
-                    show_hardware,
-                    show_assignments)
+                mock_machinewidget.assert_any_call(self.mock_machine,
+                                                   self.pc,
+                                                   self.actions,
+                                                   show_hardware,
+                                                   show_assignments)
                 mock_machinewidget.reset_mock()
 
     def test_show_matching_constraints(self, mock_machinewidget):

--- a/test/test_placement_ui.py
+++ b/test/test_placement_ui.py
@@ -304,13 +304,16 @@ class MachinesListTestCase(unittest.TestCase):
         mw2.machine = self.mock_machine2
         mw3 = MagicMock(name="mw3")
         mw3.machine = self.mock_machine3
-        mock_machinewidget.side_effect = [mw1, mw2, mw3]
+        # the repeated fourth one is the subordinate placeholder:
+        mw4 = MagicMock(name="mw4")
+        mock_machinewidget.side_effect = [mw1, mw2, mw3, mw4]
 
         ml = MachinesList(self.pc, self.actions)
-        self.assertEqual(3, len(ml.machine_widgets))
+        self.assertEqual(4, len(ml.machine_widgets))
 
         ml.filter_string = "machine1-filter_label"
         ml.update()
+        print("ml.machinewidgets is {}".format(ml.machine_widgets))
         self.assertEqual(1, len(ml.machine_widgets))
 
 
@@ -335,10 +338,11 @@ class ServicesListTestCase(unittest.TestCase):
         self.mock_maas_state.machines.return_value = self.mock_machines
 
         self.actions = []
+        self.sub_actions = []
 
     def test_widgets_config(self, mock_servicewidgetclass):
         for show_constraints in [False, True]:
-            ServicesList(self.pc, self.actions,
+            ServicesList(self.pc, self.actions, self.sub_actions,
                          show_constraints=show_constraints)
 
             mock_servicewidgetclass.assert_any_call(
@@ -354,14 +358,15 @@ class ServicesListTestCase(unittest.TestCase):
             fc.required_num_units.return_value = 1
             fc.constraints = {'cpu_count': 1000}
             mock_classesfunc.return_value = [fc]
-            sl = ServicesList(self.pc, self.actions)
+            sl = ServicesList(self.pc, self.actions, self.sub_actions)
             self.assertEqual(len(sl.service_widgets), 1)
 
     def test_machine_checks_constraints(self, mock_servicewidgetclass):
         mock_machine = make_fake_machine('fm', {'cpu_count': 0,
                                                 'storage': 0,
                                                 'memory': 0})
-        sl = ServicesList(self.pc, self.actions, machine=mock_machine)
+        sl = ServicesList(self.pc, self.actions, self.sub_actions,
+                          machine=mock_machine)
         self.assertEqual(len(sl.service_widgets), 0)
 
     def test_do_not_show_assigned(self, mock_servicewidgetclass):
@@ -370,7 +375,8 @@ class ServicesListTestCase(unittest.TestCase):
                                                 'memory': 0})
         self.pc.assign(mock_machine, CharmNovaCompute,
                        AssignmentType.LXC)
-        sl = ServicesList(self.pc, self.actions, machine=mock_machine)
+        sl = ServicesList(self.pc, self.actions, self.sub_actions,
+                          machine=mock_machine)
         classes = [sw.charm_class for sw in sl.service_widgets]
         self.assertTrue(CharmNovaCompute not in classes)
 
@@ -404,7 +410,8 @@ class ServicesListTestCase(unittest.TestCase):
                 mock_get_state.return_value = (CharmState.REQUIRED, [], [])
 
                 # rsl shows required charms
-                rsl = ServicesList(self.pc, self.actions, machine=None,
+                rsl = ServicesList(self.pc, self.actions,
+                                   self.sub_actions, machine=None,
                                    show_type='required')
                 self.assertEqual(len(mock_get_state.mock_calls), 3)
                 # should show all 3
@@ -416,7 +423,8 @@ class ServicesListTestCase(unittest.TestCase):
                                                        mock_sw3]
 
                 # usl shows ONLY un-required charms
-                usl = ServicesList(self.pc, self.actions, machine=None,
+                usl = ServicesList(self.pc, self.actions,
+                                   self.sub_actions, machine=None,
                                    show_type='non-required')
                 self.assertEqual(len(mock_get_state.mock_calls), 3)
                 # should show 0
@@ -428,7 +436,7 @@ class ServicesListTestCase(unittest.TestCase):
                                                        mock_sw3]
 
                 # asl has default show_type='all', showing all charms
-                asl = ServicesList(self.pc, self.actions)
+                asl = ServicesList(self.pc, self.actions, self.sub_actions)
                 self.assertEqual(len(mock_get_state.mock_calls), 3)
                 # should show all 3
                 self.assertEqual(len(asl.service_widgets), 3)


### PR DESCRIPTION
Prior to this branch, users had to place a sub charm (e.g. NTP or ceilometer-agent) on a specific machine, even though the deploy code ignored the placement and correctly issued a deploy with no MachineSpec.

Now, the code generates a placeholder machine to hold sub charms, and sub charms just have a button that says 'Add' instead of 'select machine'.

The placeholder machine is displayed differently from other machines (no hardware info is shown), and is at the end of the machine list. Otherwise, clearing some or all of the services off the placeholder works the same as with regular machines.