### PR TITLE
Avoid creating duplicate placeholder for subordinate charms on single

### DIFF
--- a/cloudinstall/core.py
+++ b/cloudinstall/core.py
@@ -357,11 +357,11 @@ class Controller:
 
         log.debug("existing juju machines: {}".format(self.juju_m_idmap))
 
-        def get_created_machine_id(response):
+        def get_created_machine_id(iid, response):
             d = response['Machines'][0]
             if d['Error']:
-                log.debug("Error from add_machine: {}".format(response))
-                return None
+                raise Exception("Error adding machine '{}':"
+                                "{}".format(iid, response))
             else:
                 return d['Machine']
 
@@ -375,7 +375,7 @@ class Controller:
             log.debug("adding machine with "
                       "constraints={}".format(machine.constraints))
             rv = self.juju.add_machine(constraints=machine.constraints)
-            m_id = get_created_machine_id(rv)
+            m_id = get_created_machine_id(machine.instance_id, rv)
             machine.machine_id = m_id
             rv = self.juju.set_annotations(m_id, 'machine',
                                            {'instance_id':

--- a/cloudinstall/placement/controller.py
+++ b/cloudinstall/placement/controller.py
@@ -154,7 +154,8 @@ class PlacementController:
         file_assignments = self.config.getopt('placements')
         new_assignments = defaultdict(lambda: defaultdict(list))
         for iid, d in file_assignments.items():
-            if self.maas_state is None:
+            if self.maas_state is None and \
+               iid != self.sub_placeholder.instance_id:
                 constraints = d['constraints']
                 pm = PlaceholderMachine(iid, iid,
                                         constraints)


### PR DESCRIPTION
Also adds an exception for failures in add_machine, to surface fatal problems to the user as soon as possible.