### PR TITLE
register exception callback in PegasusGUI

### DIFF
--- a/cloudinstall/gui.py
+++ b/cloudinstall/gui.py
@@ -591,6 +591,8 @@ class PegasusGUI(WidgetWrap):
 
     def __init__(self, header=None, body=None, footer=None):
         _check_encoding()  # Make sure terminal supports utf8
+        cb = self.show_exception_message
+        utils.register_async_exception_callback(cb)
         self.header = header if header else Header()
         self.body = body if body else Banner()
         self.footer = footer if footer else StatusBar('')

--- a/cloudinstall/task.py
+++ b/cloudinstall/task.py
@@ -48,9 +48,6 @@ class Tasker:
         self.config = config
         self.display_controller = display_controller
         self.loop = loop
-        cb = self.display_controller.show_exception_message
-        utils.register_async_exception_callback(cb)
-
         self.tasks = []  # (name, starttime, endtime=None)
         self.tasks_started_debug = []
         self.current_task_index = 0


### PR DESCRIPTION
since PegasusGUI is used in both install and status, but Tasker is only used in install, we should register the toplevel exception dialog box callback in PegasusGUI instead.