### PR TITLE
remove menuable

### DIFF
--- a/cloudinstall/charms/__init__.py
+++ b/cloudinstall/charms/__init__.py
@@ -1,7 +1,7 @@
 #
 # charms.py - Charm instructions to Cloud Installer
 #
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -101,7 +101,6 @@ class CharmBase:
     allow_multi_units = False
     allowed_assignment_types = list(AssignmentType)
     disabled = False
-    menuable = False
     subordinate = False
     openstack_release_min = 'i'
     depends = []

--- a/cloudinstall/charms/ceilometer.py
+++ b/cloudinstall/charms/ceilometer.py
@@ -1,4 +1,5 @@
 # Copyright 2015 James Beedy jamesbeedy@gmail.com
+# Copyright 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -27,7 +28,6 @@ class CharmCeilometer(CharmBase):
     charm_rev = 6
     display_name = 'Ceilometer'
     deploy_priority = 100
-    menuable = True
     contrib = True
     related = [('ceilometer:shared-db', 'mongodb:database'),
                ('ceilometer:identity-service',

--- a/cloudinstall/charms/ceph.py
+++ b/cloudinstall/charms/ceph.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -27,7 +27,6 @@ class CharmCeph(CharmBase):
     charm_name = 'ceph'
     charm_rev = 34
     display_name = 'Ceph'
-    menuable = True
     display_priority = DisplayPriorities.Storage
     related = [('ceph:client', 'cinder-ceph:ceph'),
                ('glance:ceph', 'ceph:client'),

--- a/cloudinstall/charms/ceph_osd.py
+++ b/cloudinstall/charms/ceph_osd.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -32,6 +32,5 @@ class CharmCephOSD(CharmBase):
                ('ntp:juju-info', 'ceph-osd:juju-info')]
     depends = ['ntp', 'ceph']
     isolate = True
-    menuable = True
 
 __charm_class__ = CharmCephOSD

--- a/cloudinstall/charms/cinder.py
+++ b/cloudinstall/charms/cinder.py
@@ -28,7 +28,6 @@ class CharmCinder(CharmBase):
     charm_name = 'cinder'
     charm_rev = 14
     display_name = 'Cinder'
-    menuable = True
     related = [('cinder:image-service', 'glance:image-service'),
                ('cinder:storage-backend',
                 'cinder-ceph:storage-backend'),

--- a/cloudinstall/charms/compute.py
+++ b/cloudinstall/charms/compute.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -27,7 +27,6 @@ class CharmNovaCompute(CharmBase):
     charm_name = 'nova-compute'
     charm_rev = 15
     display_name = 'Compute'
-    menuable = True
     display_priority = DisplayPriorities.Compute
     related = [('nova-compute:neutron-plugin',
                 'neutron-openvswitch:neutron-plugin'),

--- a/cloudinstall/charms/controller.py
+++ b/cloudinstall/charms/controller.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -29,7 +29,6 @@ class CharmNovaCloudController(CharmBase):
     charm_rev = 53
     display_name = 'Controller'
     deploy_priority = 2
-    menuable = True
     related = [('nova-cloud-controller:shared-db',
                 'mysql:shared-db'),
                ('rabbitmq-server:amqp',

--- a/cloudinstall/charms/glance.py
+++ b/cloudinstall/charms/glance.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -23,7 +23,6 @@ class CharmGlance(CharmBase):
     charm_name = 'glance'
     charm_rev = 13
     display_name = 'Glance'
-    menuable = True
     related = [('mysql:shared-db', 'glance:shared-db'),
                ('keystone:identity-service', 'glance:identity-service'),
                ('rabbitmq-server:amqp', 'glance:amqp')]

--- a/cloudinstall/charms/glance_simplestreams_sync.py
+++ b/cloudinstall/charms/glance_simplestreams_sync.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -41,7 +41,6 @@ class CharmGlanceSimplestreamsSync(CharmBase):
 
     charm_name = 'glance-simplestreams-sync'
     charm_rev = 2
-    menuable = True
     display_name = 'Glance - Simplestreams Image Sync'
     display_priority = DisplayPriorities.Other
     related = [('keystone:identity-service',

--- a/cloudinstall/charms/heat.py
+++ b/cloudinstall/charms/heat.py
@@ -1,4 +1,5 @@
 # Copyright 2015 James Beedy jamesbeedy@gmail.com
+# Copyright 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -23,7 +24,6 @@ class CharmHeat(CharmBase):
     charm_name = 'heat'
     charm_rev = 5
     display_name = 'Heat'
-    menuable = True
     related = [('keystone:identity-service',
                 'heat:identity-service'),
                ('mysql:shared-db',

--- a/cloudinstall/charms/horizon.py
+++ b/cloudinstall/charms/horizon.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -23,7 +23,6 @@ class CharmHorizon(CharmBase):
     charm_name = 'openstack-dashboard'
     charm_rev = 9
     display_name = 'Openstack Dashboard'
-    menuable = True
     related = [('keystone:identity-service',
                 'openstack-dashboard:identity-service')]
     is_core = True

--- a/cloudinstall/charms/jujugui.py
+++ b/cloudinstall/charms/jujugui.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -24,6 +24,5 @@ class CharmJujuGui(CharmBase):
     display_name = 'Juju GUI'
     display_priority = DisplayPriorities.Other
     deploy_priority = 1
-    menuable = True
 
 __charm_class__ = CharmJujuGui

--- a/cloudinstall/charms/keystone.py
+++ b/cloudinstall/charms/keystone.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -30,7 +30,6 @@ class CharmKeystone(CharmBase):
     display_name = 'Keystone'
     related = [('mysql:shared-db', 'keystone:shared-db')]
     deploy_priority = 1
-    menuable = True
     is_core = True
 
     def _is_auth_url_valid(self):

--- a/cloudinstall/charms/mongodb.py
+++ b/cloudinstall/charms/mongodb.py
@@ -1,4 +1,5 @@
 # Copyright 2015 James Beedy jamesbeedy@gmail.com
+# Copyright 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -24,7 +25,6 @@ class CharmMongo(CharmBase):
     charm_rev = 17
     display_name = 'MongoDB'
     deploy_priority = 0
-    menuable = True
     contrib = True
 
 __charm_class__ = CharmMongo

--- a/cloudinstall/charms/mysql.py
+++ b/cloudinstall/charms/mysql.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -24,7 +24,6 @@ class CharmMysql(CharmBase):
     charm_rev = 24
     display_name = 'MySQL'
     deploy_priority = 0
-    menuable = True
     is_core = True
 
 __charm_class__ = CharmMysql

--- a/cloudinstall/charms/neutron_api.py
+++ b/cloudinstall/charms/neutron_api.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -25,7 +25,6 @@ class CharmNeutronAPI(CharmBase):
     charm_name = 'neutron-api'
     charm_rev = 9
     display_name = 'Neutron API'
-    menuable = True
     openstack_release_min = 'j'
     related = [('neutron-api:identity-service',
                 'keystone:identity-service'),

--- a/cloudinstall/charms/neutron_openvswitch.py
+++ b/cloudinstall/charms/neutron_openvswitch.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -25,7 +25,6 @@ class CharmNeutronOpenvswitch(CharmBase):
     charm_name = 'neutron-openvswitch'
     charm_rev = 2
     display_name = 'Neutron OpenVSwitch'
-    menuable = True
     subordinate = True
     openstack_release_min = 'j'
     is_core = True

--- a/cloudinstall/charms/quantum.py
+++ b/cloudinstall/charms/quantum.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -38,7 +38,6 @@ class CharmQuantum(CharmBase):
                ('ntp:juju-info', 'quantum-gateway:juju-info'),
                ('rabbitmq-server:amqp', 'quantum-gateway:amqp')]
     isolate = True
-    menuable = True
     constraints = {'mem': 2048,
                    'root-disk': 20480}
     allowed_assignment_types = [AssignmentType.BareMetal,

--- a/cloudinstall/charms/rabbitmq.py
+++ b/cloudinstall/charms/rabbitmq.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -24,7 +24,6 @@ class CharmRabbitMQ(CharmBase):
     charm_rev = 26
     display_name = 'RabbitMQ Server'
     deploy_priority = 1
-    menuable = True
     related = [('rabbitmq-server:amqp',
                 'neutron-openvswitch:amqp')]
     is_core = True

--- a/cloudinstall/charms/swift.py
+++ b/cloudinstall/charms/swift.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -27,7 +27,6 @@ class CharmSwift(CharmBase):
     charm_name = 'swift-storage'
     charm_rev = 13
     display_name = 'Swift'
-    menuable = True
     display_priority = DisplayPriorities.Storage
     related = [('swift-proxy:swift-storage', 'swift:swift-storage')]
     deploy_priority = 5

--- a/cloudinstall/charms/swift_proxy.py
+++ b/cloudinstall/charms/swift_proxy.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -32,7 +32,6 @@ class CharmSwiftProxy(CharmBase):
     constraints = {'mem': 1024,
                    'root-disk': 8192}
     allow_multi_units = False
-    menuable = True
     depends = ['swift-storage']
     conflicts = ['ceph-radosgw']
 

--- a/cloudinstall/gui.py
+++ b/cloudinstall/gui.py
@@ -257,7 +257,7 @@ class ServicesView(ScrollableWidgetWrap):
             node_pile = []
             node_cols = []
             charm_class, service = node
-            if charm_class.menuable and len(service.units) > 0:
+            if len(service.units) > 0:
                 for u in sorted(service.units, key=attrgetter('unit_name')):
                     node_cols = self._build_node_columns(u, charm_class)
                     node_pile.append(node_cols)

--- a/test/files/charm_plugins/charms/horizon.py
+++ b/test/files/charm_plugins/charms/horizon.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -23,7 +23,6 @@ class CharmHorizon(CharmBase):
     charm_name = 'openstack-dashboard'
     charm_rev = 8
     display_name = 'Openstack Dashboard'
-    menuable = True
     related = ['keystone']
 
 __charm_class__ = CharmHorizon


### PR DESCRIPTION
'menuable' hides some charms from showing in the main status screen, but it's not well documented and no one remembers why some are hidden and others aren't.

Subordinate charms are not displayed because they have no units listed in 'juju status'. This does not change that.

In multi installs, this should only affect ceph-radosgw, which will now be displayed if it is deployed.

This doesn't change anything in single installs, because ceph-radosgw is not deployed in single.