### PR TITLE
Fix swift-storage <-> swift-proxy relation

### DIFF
--- a/cloudinstall/charms/__init__.py
+++ b/cloudinstall/charms/__init__.py
@@ -301,10 +301,22 @@ class CharmQueue:
 
         valid_relations = []
         for rel_a, rel_b in all_relations:
-            rel_a_name = rel_a.split(":")[0]
-            rel_b_name = rel_b.split(":")[0]
-            if rel_a_name in charm_names and rel_b_name in charm_names:
+            rel_a_svc = rel_a.split(":")[0]
+            svc_a_placed = rel_a_svc in charm_names
+            rel_b_svc = rel_b.split(":")[0]
+            svc_b_placed = rel_b_svc in charm_names
+
+            if svc_a_placed and svc_b_placed:
                 valid_relations.append((rel_a, rel_b))
+            else:
+                msg = ("relation {}:{} ignored "
+                       "because:".format(rel_a, rel_b))
+                if not svc_a_placed:
+                    msg += " {} is not placed".format(rel_a_svc)
+                if not svc_b_placed:
+                    msg += " {} is not placed".format(rel_b_svc)
+                log.info(msg)
+
         return valid_relations
 
     def add_deploy(self, charm):

--- a/cloudinstall/charms/swift.py
+++ b/cloudinstall/charms/swift.py
@@ -28,7 +28,7 @@ class CharmSwift(CharmBase):
     charm_rev = 13
     display_name = 'Swift'
     display_priority = DisplayPriorities.Storage
-    related = [('swift-proxy:swift-storage', 'swift:swift-storage')]
+    related = [('swift-proxy:swift-storage', 'swift-storage:swift-storage')]
     deploy_priority = 5
     default_replicas = 3
     isolate = True


### PR DESCRIPTION
Fixes #505. Swift was not started because relation to swift-storage was not made.

Tested in single-install by checking that 'swift stat' returns something meaningful and that 'swift list' shows the images from glance.
(Note, you need to use something like this to look in swift using the right user account:
`OS_USERNAME=image-stream OS_TENANT_NAME=services OS_PASSWORD=$pass swift list`
where `$pass` is the long hex password that can be found in /etc/glance-simplestreams-sync/identity.yaml on the glance-simplestreams-sync unit.

Also adds logging to help diagnose this in the future.