### PR TITLE
Use placement infrastructure for add-services dialog

### DIFF
--- a/bin/openstack-status
+++ b/bin/openstack-status
@@ -112,9 +112,10 @@ if __name__ == '__main__':
         import atexit
         atexit.register(partial(utils.cleanup, config))
         core.start()
-    except:
+    except Exception as e:
         if opts.debug and not config.getopt('headless'):
             import pdb
             pdb.post_mortem()
+        raise e
     finally:
         sys.exit(ev.error_code)

--- a/cloudinstall/charms/__init__.py
+++ b/cloudinstall/charms/__init__.py
@@ -271,7 +271,6 @@ class CharmQueue:
 
     def __init__(self, ui, config, juju_state=None, juju=None,
                  deployed_charms=None):
-        self.charm_deploy_q = Queue()
         self.charm_post_proc_q = Queue()
         self.is_running = False
         self.ui = ui
@@ -318,24 +317,6 @@ class CharmQueue:
                 log.info(msg)
 
         return valid_relations
-
-    def add_deploy(self, charm):
-        self.charm_deploy_q.put(charm)
-
-    def watch_deploy(self):
-        log.debug("Starting charm deploy watcher.")
-        while not self.charm_deploy_q.empty():
-            try:
-                charm = self.charm_deploy_q.get()
-                err = charm.deploy()  # TODO call with machine placement
-                if err:
-                    self.charm_deploy_q.put(charm)
-                self.charm_deploy_q.task_done()
-            except:
-                msg = "Exception in deploy watcher, re-trying."
-                log.exception(msg)
-                self.ui.status_error_message(msg)
-            time.sleep(10)
 
     @utils.async
     def watch_relations_async(self):

--- a/cloudinstall/core.py
+++ b/cloudinstall/core.py
@@ -668,7 +668,7 @@ class Controller:
         else:
             self.ui.status_info_message("Welcome")
             self.initialize()
-            self.loop.register_callback('add_charm', self.add_charm)
+            self.loop.register_callback('add_services', self.add_charm)
             self.loop.register_callback('refresh_display', self.update)
             self.loop.set_alarm_in(0, self.update)
             self.loop.run()

--- a/cloudinstall/core.py
+++ b/cloudinstall/core.py
@@ -277,9 +277,8 @@ class Controller:
             controller_machine = self.juju_m_idmap['controller']
             self.configure_lxc_network(controller_machine)
 
-        # FIXME: this is never populated during a multi_install
-        # for juju_machine_id in self.juju_m_idmap.values():
-        #    self.run_apt_go_fast(juju_machine_id)
+            for juju_machine_id in self.juju_m_idmap.values():
+                self.run_apt_go_fast(juju_machine_id)
 
         if self.config.is_single():
             # FIXME: Remove once http://pad.lv/1326091 is fixed

--- a/cloudinstall/ev.py
+++ b/cloudinstall/ev.py
@@ -70,14 +70,8 @@ class EventLoop:
                 if self.config.getopt('current_state') != \
                    ControllerState.SERVICES:
                     return
-                charm_modules = utils.load_charms(
-                    self.config.getopt('charm_plugin_dir'))
-                charm_classes = [m.__charm_class__ for m in charm_modules
-                                 if m.__charm_class__.allow_multi_units and
-                                 not m.__charm_class__.disabled]
-                # FIXME: Add unecessary confusion
-                self.ui.show_add_charm_info(charm_classes,
-                                            self._callback_map['add_charm'])
+                cb = self._callback_map['add_services']
+                self.ui.show_add_services_dialog(cb)
             if key in ['q', 'Q']:
                 self.exit(0)
             if key in ['r', 'R', 'f5']:

--- a/cloudinstall/ev.py
+++ b/cloudinstall/ev.py
@@ -19,6 +19,9 @@ import sys
 import cloudinstall.utils as utils
 from cloudinstall.state import ControllerState
 
+import logging
+
+log = logging.getLogger('cloudinstall.ev')
 
 class EventLoop:
 
@@ -109,7 +112,11 @@ class EventLoop:
         :param func cb: (optional) callback
         """
         if not self.config.getopt('headless'):
-            self.loop.run()
+            try:
+                self.loop.run()
+            except:
+                log.exception("Exception in ev.run():")
+                raise
         return
 
     def __repr__(self):

--- a/cloudinstall/ev.py
+++ b/cloudinstall/ev.py
@@ -23,6 +23,7 @@ import logging
 
 log = logging.getLogger('cloudinstall.ev')
 
+
 class EventLoop:
 
     """ Abstracts out event loops in different scenarios

--- a/cloudinstall/ev.py
+++ b/cloudinstall/ev.py
@@ -74,8 +74,8 @@ class EventLoop:
                 if self.config.getopt('current_state') != \
                    ControllerState.SERVICES:
                     return
-                cb = self._callback_map['add_services']
-                self.ui.show_add_services_dialog(cb)
+                self.config.setopt('current_state',
+                                   ControllerState.ADD_SERVICES.value)
             if key in ['q', 'Q']:
                 self.exit(0)
             if key in ['r', 'R', 'f5']:

--- a/cloudinstall/gui.py
+++ b/cloudinstall/gui.py
@@ -639,7 +639,7 @@ class PegasusGUI(WidgetWrap):
                           bottom_w=self.frame,
                           align='center',
                           valign='middle',
-                          width=80,
+                          width=('relative', 75),
                           height='pack',
                           min_width=40)
 

--- a/cloudinstall/gui.py
+++ b/cloudinstall/gui.py
@@ -513,6 +513,7 @@ class PegasusGUI(WidgetWrap):
         self.placement_view = None
         self.controller = None
         self.machine_wait_view = None
+        self.add_services_dialog = None
         super().__init__(self.frame)
 
     def _build_overlay_widget(self,
@@ -550,16 +551,20 @@ class PegasusGUI(WidgetWrap):
                                              min_height=min_height)
 
     def focus_next(self):
-        self.frame.body.scroll_down()
+        if hasattr(self.frame.body, 'scroll_down'):
+            self.frame.body.scroll_down()
 
     def focus_previous(self):
-        self.frame.body.scroll_up()
+        if hasattr(self.frame.body, 'scroll_up'):
+            self.frame.body.scroll_up()
 
     def focus_first(self):
-        self.frame.body.scroll_top()
+        if hasattr(self.frame.body, 'scroll_top'):
+            self.frame.body.scroll_top()
 
     def focus_last(self):
-        self.frame.body.scroll_bottom()
+        if hasattr(self.frame.body, 'scroll_bottom'):
+            self.frame.body.scroll_bottom()
 
     def hide_widget_on_top(self):
         """Hide the topmost widget (if any)."""
@@ -632,17 +637,6 @@ class PegasusGUI(WidgetWrap):
     def hide_show_landscape_input(self):
         self.hide_widget_on_top()
 
-    def show_add_services_dialog(self, cb):
-        widget = AddServicesDialog(self.controller, deploy_cb=cb,
-                                   cancel_cb=self.hide_widget_on_top)
-        self._w = Overlay(top_w=widget,
-                          bottom_w=self.frame,
-                          align='center',
-                          valign='middle',
-                          width=('relative', 75),
-                          height='pack',
-                          min_width=40)
-
     def set_pending_deploys(self, pending_charms):
         self.frame.footer.set_pending_deploys(pending_charms)
 
@@ -709,6 +703,21 @@ class PegasusGUI(WidgetWrap):
                 self, self.current_installer, config)
         self.machine_wait_view.update()
         self.frame.body = self.machine_wait_view
+
+    def render_add_services_dialog(self, deploy_cb):
+        def reset():
+            self.add_services_dialog = None
+
+        def deploy():
+            reset()
+            deploy_cb()
+
+        if self.add_services_dialog is None:
+            self.add_services_dialog = AddServicesDialog(self.controller,
+                                                         deploy_cb=deploy,
+                                                         cancel_cb=reset)
+        self.add_services_dialog.update()
+        self.frame.body = Filler(self.add_services_dialog)
 
     def show_exception_message(self, ex, logpath="~/.cloud-install/commands"):
         def handle_done(*args, **kwargs):

--- a/cloudinstall/gui.py
+++ b/cloudinstall/gui.py
@@ -511,6 +511,7 @@ class PegasusGUI(WidgetWrap):
 
         self.services_view = None
         self.placement_view = None
+        self.controller = None
         self.machine_wait_view = None
         super().__init__(self.frame)
 
@@ -632,11 +633,15 @@ class PegasusGUI(WidgetWrap):
         self.hide_widget_on_top()
 
     def show_add_services_dialog(self, cb):
-        widget = AddServicesDialog(cb)
-        self.show_widget_on_top(widget, width=50, height=10)
-
-    def hide_add_services_dialog(self):
-        self.hide_widget_on_top()
+        widget = AddServicesDialog(self.controller, ok_cb=cb,
+                                   cancel_cb=self.hide_widget_on_top)
+        self._w = Overlay(top_w=widget,
+                          bottom_w=self.frame,
+                          align='center',
+                          valign='middle',
+                          width=80,
+                          height='pack',
+                          min_width=40)
 
     def set_pending_deploys(self, pending_charms):
         self.frame.footer.set_pending_deploys(pending_charms)
@@ -685,17 +690,16 @@ class PegasusGUI(WidgetWrap):
         self.frame.body = NodeInstallWaitMode(message, **kwargs)
         self.frame.set_body(self.frame.body)
 
-    def render_placement_view(self, placement_controller, loop, config, cb):
+    def render_placement_view(self, loop, config, cb):
         """ render placement view
 
         :param cb: deploy callback trigger
         """
         if self.placement_view is None:
-            self.placement_view = PlacementView(self,
-                                                placement_controller,
-                                                loop,
-                                                config,
-                                                cb)
+            assert self.controller is not None
+            pc = self.controller.placement_controller
+            self.placement_view = PlacementView(self, pc, loop,
+                                                config, cb)
         self.placement_view.update()
         self.frame.body = self.placement_view
 

--- a/cloudinstall/gui.py
+++ b/cloudinstall/gui.py
@@ -633,7 +633,7 @@ class PegasusGUI(WidgetWrap):
         self.hide_widget_on_top()
 
     def show_add_services_dialog(self, cb):
-        widget = AddServicesDialog(self.controller, ok_cb=cb,
+        widget = AddServicesDialog(self.controller, deploy_cb=cb,
                                    cancel_cb=self.hide_widget_on_top)
         self._w = Overlay(top_w=widget,
                           bottom_w=self.frame,

--- a/cloudinstall/placement/controller.py
+++ b/cloudinstall/placement/controller.py
@@ -134,7 +134,7 @@ class PlacementController:
         assignments temporarily, e.g. for supporting cancellable
         assignments in a dialog box.
 
-        Pairs with read_from_controller() to 'commit' those temporary
+        Pairs with update_from_controller() to 'commit' those temporary
         assignments to the 'main' controller.
         """
         newpc = PlacementController(maas_state=self.maas_state,
@@ -151,6 +151,14 @@ class PlacementController:
 
         self.assignments = other.assignments
         self.deployments = other.deployments
+        self.reset_assigned_deployed()
+
+    def set_assignments_from_deployments(self):
+        """Reset deployment state of all services. Useful after reading a file
+        from a previous install.
+        """
+        self.assignments = self.deployments
+        self.deployments = defaultdict(lambda: defaultdict(list))
         self.reset_assigned_deployed()
 
     def __repr__(self):

--- a/cloudinstall/placement/controller.py
+++ b/cloudinstall/placement/controller.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from collections import defaultdict, Counter
+import copy
 from enum import Enum
 import logging
 import yaml
@@ -139,8 +140,8 @@ class PlacementController:
         """
         newpc = PlacementController(maas_state=self.maas_state,
                                     config=self.config)
-        newpc.assignments = self.assignments
-        newpc.deployments = self.deployments
+        newpc.assignments = copy.copy(self.assignments)
+        newpc.deployments = copy.copy(self.deployments)
         newpc._machines = self._machines
         newpc.reset_assigned_deployed()
         return newpc

--- a/cloudinstall/placement/ui/__init__.py
+++ b/cloudinstall/placement/ui/__init__.py
@@ -63,7 +63,7 @@ class ServicesColumn(WidgetWrap):
 
         actions = [(not_conflicted_p, "Choose Machine",
                     self.placement_view.do_show_machine_chooser)]
-        subordinate_actions = [("Add",
+        subordinate_actions = [(not_conflicted_p, "Add",
                                 self.do_place_subordinate)]
         self.required_services_list = ServicesList(self.placement_controller,
                                                    actions,

--- a/cloudinstall/placement/ui/__init__.py
+++ b/cloudinstall/placement/ui/__init__.py
@@ -68,7 +68,8 @@ class ServicesColumn(WidgetWrap):
         self.required_services_list = ServicesList(self.placement_controller,
                                                    actions,
                                                    subordinate_actions,
-                                                   unplaced_only=True,
+                                                   ignore_assigned=True,
+                                                   ignore_deployed=True,
                                                    show_type='required',
                                                    show_constraints=True,
                                                    title="Required Services")
@@ -118,8 +119,8 @@ class ServicesColumn(WidgetWrap):
         self.additional_services_list.update()
 
         top_buttons = []
-
-        if len(self.placement_controller.unplaced_services) == 0:
+        unplaced = self.placement_controller.unassigned_undeployed_services()
+        if len(unplaced) == 0:
             icon = SelectableIcon(" (Auto-place Remaining Services) ")
             top_buttons.append((AttrMap(icon,
                                         'disabled_button',
@@ -170,7 +171,7 @@ class DeployView(WidgetWrap):
             'button_primary', 'button_primary focus')
         self.deploy_grid = GridFlow([self.deploy_button], 10, 1, 0, 'center')
 
-        self.unplaced_msg = "Some required services are still unplaced."
+        self.unplaced_msg = "Some required services are still unassigned."
 
         self.main_pile = Pile([Divider()])
         return self.main_pile
@@ -372,7 +373,7 @@ class PlacementView(WidgetWrap):
         self.machines_column.update()
 
     def do_autoplace(self, sender):
-        ok, msg = self.placement_controller.autoplace_unplaced_services()
+        ok, msg = self.placement_controller.autoassign_unassigned_services()
         if not ok:
             self.show_overlay(InfoDialog(msg, self.remove_overlay))
 

--- a/cloudinstall/placement/ui/add_services_dialog.py
+++ b/cloudinstall/placement/ui/add_services_dialog.py
@@ -15,7 +15,7 @@
 
 import logging
 
-from urwid import (AttrMap, Button, Columns, Divider, GridFlow,
+from urwid import (AttrMap, Button, Columns, GridFlow,
                    LineBox, Pile, SelectableIcon, WidgetWrap)
 
 from cloudinstall.placement.controller import AssignmentType
@@ -59,11 +59,6 @@ class AddServicesDialog(WidgetWrap):
 
         actions = [(remove_p, 'Remove', self.do_remove),
                    (not_conflicted_p, 'Add', self.do_add)]
-        self.required_sl = ServicesList(self.pc,
-                                        actions, actions,
-                                        show_type='required',
-                                        show_placements=True,
-                                        title="Required for Deploy")
         self.unrequired_undeployed_sl = ServicesList(self.pc,
                                                      actions, actions,
                                                      ignore_deployed=True,
@@ -82,17 +77,13 @@ class AddServicesDialog(WidgetWrap):
 
         self.buttons = []
         self.button_grid = GridFlow(self.buttons, 22, 1, 1, 'center')
-        self.pile1 = Pile([self.required_sl,
-                               self.unrequired_undeployed_sl])
+        self.pile1 = Pile([self.button_grid, self.assigned_sl,
+                           self.unrequired_undeployed_sl])
         self.pile2 = Pile([self.deployed_sl])
-        self.pile3 = Pile([self.assigned_sl])
-        return LineBox(Pile([Columns([self.pile1, self.pile2, self.pile3]),
-                             Divider(),
-                             self.button_grid]),
+        return LineBox(Columns([self.pile1, self.pile2]),
                        title="Add Services")
 
     def update(self):
-        self.required_sl.update()
         self.unrequired_undeployed_sl.update()
         self.deployed_sl.update()
         self.assigned_sl.update()

--- a/cloudinstall/placement/ui/add_services_dialog.py
+++ b/cloudinstall/placement/ui/add_services_dialog.py
@@ -45,26 +45,20 @@ class AddServicesDialog(WidgetWrap):
         self.count_editor = None
         self.boxes = []
 
-        w = self._build_widget()
+        w = self.build_widget()
         w = AttrWrap(w, "dialog")
 
         super().__init__(w)
 
-    def submit(self):
-        """ Handle OK submit """
-        selected = [r for r in self.boxes if
-                    r is not self.count_editor and
-                    r.get_state()][0]
-        _charm_to_deploy = selected.label
-        n = self.count_editor.value()
-        self.cb(n, _charm_to_deploy)
+    def do_deploy(self):
+        self.cb()  # TODO
 
     def cancel(self):
         """ Handle cancel action """
-        self.cb()
+        self.cb()  # TODO
 
-    def _build_widget(self, **kwargs):
-        # Charm selections
+    def build_widget(self, **kwargs):
+
         num_of_items, charm_sel = self._insert_charm_selections()
 
         # Control buttons

--- a/cloudinstall/placement/ui/add_services_dialog.py
+++ b/cloudinstall/placement/ui/add_services_dialog.py
@@ -35,11 +35,11 @@ class AddServicesDialog(WidgetWrap):
     :param cb: callback routine to process submit/cancel actions
     """
 
-    def __init__(self, install_controller, ok_cb, cancel_cb):
+    def __init__(self, install_controller, deploy_cb, cancel_cb):
         self.install_controller = install_controller
         self.placement_controller = install_controller.placement_controller
         self.charms = []
-        self.ok_cb = ok_cb
+        self.deploy_cb = deploy_cb
         self.cancel_cb = cancel_cb
         self.boxes = []
 
@@ -51,10 +51,12 @@ class AddServicesDialog(WidgetWrap):
         actions = [('Add', self.do_add)]
         self.services_list = ServicesList(self.placement_controller,
                                           actions, actions,
-                                          unplaced_only=True,
+                                          ignore_assigned=False,
+                                          ignore_deployed=True,
                                           show_placements=True)
-        self.buttons = Columns([Button("OK", self.handle_ok),
-                                Button("Cancel", self.handle_cancel)])
+
+        self.buttons = Columns([Button("Cancel", self.handle_cancel),
+                                Button("Deploy", self.handle_deploy)])
 
         self.main_pile = Pile([self.services_list,
                                Divider(), self.buttons])
@@ -72,8 +74,8 @@ class AddServicesDialog(WidgetWrap):
                                          AssignmentType.DEFAULT)
         self.update()
 
-    def handle_ok(self, button):
-        self.ok_cb()
+    def handle_deploy(self, button):
+        self.deploy_cb()
 
     def handle_cancel(self, button):
         self.cancel_cb()

--- a/cloudinstall/placement/ui/add_services_dialog.py
+++ b/cloudinstall/placement/ui/add_services_dialog.py
@@ -1,0 +1,113 @@
+# Copyright 2015 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+
+from urwid import (AttrWrap, Button, BoxAdapter, Columns, Divider, IntEdit,
+                   LineBox, ListBox, RadioButton, SimpleListWalker, WidgetWrap)
+
+# from cloudinstall.placement.ui.machine_chooser import MachineChooser
+# from cloudinstall.placement.ui.machines_list import MachinesList
+# from cloudinstall.placement.ui.service_chooser import ServiceChooser
+# from cloudinstall.placement.ui.services_list import ServicesList
+# from cloudinstall.ui import InfoDialog
+# from cloudinstall.state import CharmState
+
+log = logging.getLogger('cloudinstall.placement')
+
+
+BUTTON_SIZE = 20
+
+
+class AddServicesDialog(WidgetWrap):
+
+    """ Adding charm dialog
+
+    :param cb: callback routine to process submit/cancel actions
+    :returns: input from dialog
+    """
+
+    def __init__(self, cb, **kwargs):
+        self.charms = []
+        self.cb = cb
+        self.count_editor = None
+        self.boxes = []
+
+        w = self._build_widget()
+        w = AttrWrap(w, "dialog")
+
+        super().__init__(w)
+
+    def submit(self):
+        """ Handle OK submit """
+        selected = [r for r in self.boxes if
+                    r is not self.count_editor and
+                    r.get_state()][0]
+        _charm_to_deploy = selected.label
+        n = self.count_editor.value()
+        self.cb(n, _charm_to_deploy)
+
+    def cancel(self):
+        """ Handle cancel action """
+        self.cb()
+
+    def _build_widget(self, **kwargs):
+        # Charm selections
+        num_of_items, charm_sel = self._insert_charm_selections()
+
+        # Control buttons
+        buttons = self._insert_buttons()
+
+        return LineBox(
+            BoxAdapter(
+                ListBox([charm_sel, Divider(), buttons]),
+                height=num_of_items + 2),
+            title="Add unit")
+
+    def _insert_charm_selections(self):
+        first_index = 0
+        bgroup = []
+        for i, charm_class in enumerate(self.charms):
+            charm = charm_class
+            if charm.name() and not first_index:
+                first_index = i
+            r = RadioButton(bgroup, charm.name())
+            r.text_label = charm.name()
+            self.boxes.append(r)
+
+        # Add input widget for specifying NumUnits
+        self.count_editor = IntEdit("Number of units to add: ", 1)
+        self.boxes.append(self.count_editor)
+        wrapped_boxes = self._wrap_focus(self.boxes)
+        items = ListBox(SimpleListWalker(wrapped_boxes))
+        items.set_focus(first_index)
+        return (len(self.boxes), BoxAdapter(items, len(self.boxes)))
+
+    def _insert_buttons(self):
+        bs = [Button("Ok", self.yes), Button("Cancel", self.no)]
+        wrapped_buttons = self._wrap_focus(bs)
+        return Columns(wrapped_buttons)
+
+    def yes(self, button):
+        self.submit()
+
+    def no(self, button):
+        self.cancel()
+
+    def _wrap_focus(self, widgets, unfocused=None):
+        try:
+            return [AttrWrap(w, "focus", 'radio focus') for w in widgets]
+        except TypeError:
+            return AttrWrap(widgets, "focus", 'radio focus')

--- a/cloudinstall/placement/ui/machine_widget.py
+++ b/cloudinstall/placement/ui/machine_widget.py
@@ -100,6 +100,10 @@ class MachineWidget(WidgetWrap):
         if self.machine == self.controller.sub_placeholder:
             self.machine_info_widget.set_text("\N{BULLET} Subordinate Charms")
             self.hardware_widget.set_text("")
+        elif self.machine == self.controller.def_placeholder:
+            self.machine_info_widget.set_text("\N{BULLET} Juju Default "
+                                              "Placement")
+            self.hardware_widget.set_text("")
         else:
             info_markup = ["\N{TAPE DRIVE} {}".format(self.machine.hostname),
                            ('label', " ({})".format(self.machine.status))]

--- a/cloudinstall/placement/ui/machines_list.py
+++ b/cloudinstall/placement/ui/machines_list.py
@@ -105,6 +105,14 @@ class MachinesList(WidgetWrap):
 
         n_satisfying_machines = len(machines)
 
+        def get_placement_filter_label(d):
+            s = ""
+            for atype, al in d.items():
+                s += " ".join(["{} {}".format(cc.charm_name,
+                                              cc.display_name)
+                               for cc in al])
+            return s
+
         for m in machines:
             if not satisfies(m, self.constraints)[0]:
                 self.remove_machine(m)
@@ -113,12 +121,12 @@ class MachinesList(WidgetWrap):
 
             assignment_names = ""
             ad = self.controller.assignments_for_machine(m)
-            for atype, al in ad.items():
-                assignment_names += " ".join(["{} {}".format(cc.charm_name,
-                                                             cc.display_name)
-                                              for cc in al])
-            filter_label = "{} {}".format(m.filter_label(),
-                                          assignment_names)
+            assignment_names = get_placement_filter_label(ad)
+            dd = self.controller.deployments_for_machine(m)
+            deployment_names = get_placement_filter_label(dd)
+            filter_label = "{} {} {}".format(m.filter_label(),
+                                             assignment_names,
+                                             deployment_names)
 
             if self.filter_string != "" and \
                self.filter_string not in filter_label:
@@ -126,6 +134,7 @@ class MachinesList(WidgetWrap):
                 continue
 
             mw = self.find_machine_widget(m)
+
             if mw is None:
                 mw = self.add_machine_widget(m)
             mw.update()
@@ -147,9 +156,9 @@ class MachinesList(WidgetWrap):
 
     def remove_machine(self, machine):
         mw = self.find_machine_widget(machine)
-
         if mw is None:
             return
+
         self.machine_widgets.remove(mw)
         mw_idx = 0
         for w, opts in self.machine_pile.contents:

--- a/cloudinstall/placement/ui/service_chooser.py
+++ b/cloudinstall/placement/ui/service_chooser.py
@@ -47,7 +47,7 @@ class ServiceChooser(WidgetWrap):
                                             show_hardware=True)
 
         def show_remove_p(cc):
-            md = self.controller.machines_for_charm(cc)
+            md = self.controller.get_assignments(cc)
             for atype, ms in md.items():
                 hostnames = [m.hostname for m in ms]
                 if self.machine.hostname in hostnames:

--- a/cloudinstall/placement/ui/service_chooser.py
+++ b/cloudinstall/placement/ui/service_chooser.py
@@ -31,6 +31,11 @@ class ServiceChooser(WidgetWrap):
     """
 
     def __init__(self, controller, machine, parent_widget):
+        """
+        controller is a PlacementController
+        machine is the machine to show Services for
+        parent_widget should support 'remove_overlay()'
+        """
         self.controller = controller
         self.machine = machine
         self.parent_widget = parent_widget

--- a/cloudinstall/placement/ui/service_widget.py
+++ b/cloudinstall/placement/ui/service_widget.py
@@ -127,8 +127,8 @@ class ServiceWidget(WidgetWrap):
             self.charm_info_widget.set_text(self.title_markup)
 
         def string_for_placement_dict(d):
-            s = [""]
-            for atype, ml in ad.items():
+            s = []
+            for atype, ml in d.items():
                 n = len(ml)
                 s.append(('label', "    {} ({}): ".format(atype.name, n)))
                 if len(ml) == 0:
@@ -136,13 +136,15 @@ class ServiceWidget(WidgetWrap):
                 else:
                     s.append(", ".join(["\N{TAPE DRIVE} {}".format(m.hostname)
                                         for m in ml]))
+            if len(s) == 0:
+                return [('label', "None")]
             return s
-        mstr.append("Assignments:")
+        mstr += ["    ", ('label', "Assignments: ")]
         ad = self.controller.get_assignments(self.charm_class)
-        mstr.append(string_for_placement_dict(ad))
-        mstr.append("\nDeployments")
         dd = self.controller.get_deployments(self.charm_class)
-        mstr.append(string_for_placement_dict(dd))
+        mstr += string_for_placement_dict(ad)
+        mstr += ["\n    ", ('label', "Deployments: ")]
+        mstr += string_for_placement_dict(dd)
 
         self.placements_widget.set_text(mstr)
 

--- a/cloudinstall/placement/ui/service_widget.py
+++ b/cloudinstall/placement/ui/service_widget.py
@@ -93,18 +93,22 @@ class ServiceWidget(WidgetWrap):
         return Padding(p, left=2, right=2)
 
     def update(self):
-        md = self.controller.machines_for_charm(self.charm_class)
         mstr = [""]
 
         state, cons, deps = self.controller.get_charm_state(self.charm_class)
 
         if state == CharmState.REQUIRED:
-            np = self.controller.machine_count_for_charm(self.charm_class)
+            p = self.controller.get_assignments(self.charm_class)
+            d = self.controller.get_deployments(self.charm_class)
             nr = self.charm_class.required_num_units()
-            info_str = " ({} of {} placed)".format(np, nr)
+            info_str = " ({} of {} placed".format(len(p), nr)
+            if len(d) > 0:
+                info_str += ", {} deployed)".format(len(d))
+            else:
+                info_str += ")"
 
             # Add hint to explain why a dep showed up in required
-            if np == 0 and len(deps) > 0:
+            if len(p) == 0 and len(deps) > 0:
                 dep_str = ", ".join([c.display_name for c in deps])
                 info_str += " - required by {}".format(dep_str)
 
@@ -120,7 +124,8 @@ class ServiceWidget(WidgetWrap):
             self.title_markup[1] = ""
             self.charm_info_widget.set_text(self.title_markup)
 
-        for atype, ml in md.items():
+        pd = self.controller.get_assignments(self.charm_class)
+        for atype, ml in pd.items():
             n = len(ml)
             mstr.append(('label', "    {} ({}): ".format(atype.name, n)))
             if len(ml) == 0:

--- a/cloudinstall/placement/ui/services_list.py
+++ b/cloudinstall/placement/ui/services_list.py
@@ -29,6 +29,8 @@ class ServicesList(WidgetWrap):
 
     """A list of services (charm classes) with flexible display options.
 
+    Note that not all combinations of display options make sense. YMMV.
+
     controller - a PlacementController
 
     actions - a list of tuples describing buttons. Passed to
@@ -44,14 +46,20 @@ class ServicesList(WidgetWrap):
     ignore_deployed - bool, whether or not to display services that
     have already been deployed
 
+    deployed_only - bool, only show deployed services
+
     show_constraints - bool, whether or not to display the constraints
     for the various services
+
+    show_type - string, one of 'all', 'required' or 'non-required',
+    controls which charm states should be shown. default is 'all'.
 
     """
 
     def __init__(self, controller, actions, subordinate_actions,
                  machine=None, ignore_assigned=False,
-                 ignore_deployed=False, show_type='all',
+                 ignore_deployed=False, deployed_only=False,
+                 show_type='all',
                  show_constraints=False, show_placements=False,
                  title="Services"):
         self.controller = controller
@@ -61,6 +69,7 @@ class ServicesList(WidgetWrap):
         self.machine = machine
         self.ignore_assigned = ignore_assigned
         self.ignore_deployed = ignore_deployed
+        self.deployed_only = deployed_only
         self.show_type = show_type
         self.show_constraints = show_constraints
         self.show_placements = show_placements
@@ -106,6 +115,10 @@ class ServicesList(WidgetWrap):
                 n = self.controller.deployment_machine_count_for_charm(cc)
                 if n == cc.required_num_units() \
                    and self.controller.is_deployed(cc):
+                    self.remove_service_widget(cc)
+                    continue
+            elif self.deployed_only:
+                if not self.controller.is_deployed(cc):
                     self.remove_service_widget(cc)
                     continue
 

--- a/cloudinstall/placement/ui/services_list.py
+++ b/cloudinstall/placement/ui/services_list.py
@@ -38,6 +38,12 @@ class ServicesList(WidgetWrap):
     None, no constraint checking is done. If set, only services whose
     constraints are satisfied by 'machine' are shown.
 
+    ignore_assigned - bool, whether or not to display services that
+    have already been assigned to a machine (but not yet deployed)
+
+    ignore_deployed - bool, whether or not to display services that
+    have already been deployed
+
     show_constraints - bool, whether or not to display the constraints
     for the various services
 
@@ -88,10 +94,6 @@ class ServicesList(WidgetWrap):
                            self.controller.is_deployed_to(cc, self.machine)):
                     self.remove_service_widget(cc)
                     continue
-
-            # refactor TODO:
-            # rename serviceslist unplaced_only to ignore_assigned and
-            # ignore_deployed
 
             if self.ignore_assigned:
                 n = self.controller.assignment_machine_count_for_charm(cc)

--- a/cloudinstall/placement/ui/services_list.py
+++ b/cloudinstall/placement/ui/services_list.py
@@ -58,8 +58,8 @@ class ServicesList(WidgetWrap):
 
     def __init__(self, controller, actions, subordinate_actions,
                  machine=None, ignore_assigned=False,
-                 ignore_deployed=False, deployed_only=False,
-                 show_type='all',
+                 ignore_deployed=False, assigned_only=False,
+                 deployed_only=False, show_type='all',
                  show_constraints=False, show_placements=False,
                  title="Services"):
         self.controller = controller
@@ -69,6 +69,7 @@ class ServicesList(WidgetWrap):
         self.machine = machine
         self.ignore_assigned = ignore_assigned
         self.ignore_deployed = ignore_deployed
+        self.assigned_only = assigned_only
         self.deployed_only = deployed_only
         self.show_type = show_type
         self.show_constraints = show_constraints
@@ -104,12 +105,22 @@ class ServicesList(WidgetWrap):
                     self.remove_service_widget(cc)
                     continue
 
+            if self.ignore_assigned and self.assigned_only:
+                raise Exception("Can't both ignore and only show assigned.")
+
             if self.ignore_assigned:
                 n = self.controller.assignment_machine_count_for_charm(cc)
                 if n == cc.required_num_units() \
                    and self.controller.is_assigned(cc):
                     self.remove_service_widget(cc)
                     continue
+            elif self.assigned_only:
+                if not self.controller.is_assigned(cc):
+                    self.remove_service_widget(cc)
+                    continue
+
+            if self.ignore_deployed and self.deployed_only:
+                raise Exception("Can't both ignore and only show deployed.")
 
             if self.ignore_deployed:
                 n = self.controller.deployment_machine_count_for_charm(cc)

--- a/cloudinstall/placement/ui/services_list.py
+++ b/cloudinstall/placement/ui/services_list.py
@@ -13,6 +13,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
+
 from urwid import (AttrMap, Divider, Padding, Pile, Text,
                    WidgetWrap)
 
@@ -20,6 +22,7 @@ from cloudinstall.maas import satisfies
 from cloudinstall.state import CharmState
 from cloudinstall.placement.ui.service_widget import ServiceWidget
 
+log = logging.getLogger('cloudinstall.placement.ui')
 
 class ServicesList(WidgetWrap):
 

--- a/cloudinstall/placement/ui/services_list.py
+++ b/cloudinstall/placement/ui/services_list.py
@@ -78,9 +78,10 @@ class ServicesList(WidgetWrap):
                     continue
 
             if self.unplaced_only:
-                n_units = self.controller.machine_count_for_charm(cc)
-                if n_units == cc.required_num_units() \
-                   and cc not in self.controller.unplaced_services:
+                n = (self.controller.placement_machine_count_for_charm(cc)
+                     + self.controller.deployment_machine_count_for_charm(cc))
+                if n == cc.required_num_units() \
+                   and self.controller.is_placed_or_deployed(cc):
                     self.remove_service_widget(cc)
                     continue
 

--- a/cloudinstall/state.py
+++ b/cloudinstall/state.py
@@ -32,6 +32,7 @@ class ControllerState(IntEnum):
     INSTALL_WAIT = 0
     PLACEMENT = 1
     SERVICES = 2
+    ADD_SERVICES = 3
 
 
 class CharmState(Enum):

--- a/test/test_placement_ui.py
+++ b/test/test_placement_ui.py
@@ -108,18 +108,18 @@ class ServiceWidgetTestCase(unittest.TestCase):
 
         self.assertFalse(search_in_widget(".* of .* placed", w))
 
-    def test_show_assignments(self):
-        """Widget with show_assignments set should show assignments"""
+    def test_show_placements(self):
+        """Widget with show_placements set should show placements"""
         self.pc.assign(self.mock_machine, CharmNovaCompute, AssignmentType.LXC)
-        w = ServiceWidget(CharmNovaCompute, self.pc, show_assignments=True)
+        w = ServiceWidget(CharmNovaCompute, self.pc, show_placements=True)
 
         self.assertTrue(search_in_widget("LXC.*machine1-hostname", w))
 
-    def test_dont_show_assignments(self):
-        """Widget with show_assignments set to FALSE should NOT show
-        assignments"""
+    def test_dont_show_placements(self):
+        """Widget with show_placements set to FALSE should NOT show
+        placements"""
         self.pc.assign(self.mock_machine, CharmNovaCompute, AssignmentType.LXC)
-        w = ServiceWidget(CharmNovaCompute, self.pc, show_assignments=False)
+        w = ServiceWidget(CharmNovaCompute, self.pc, show_placements=False)
 
         self.assertFalse(search_in_widget("LXC.*machine1-hostname", w))
 
@@ -304,12 +304,15 @@ class MachinesListTestCase(unittest.TestCase):
         mw2.machine = self.mock_machine2
         mw3 = MagicMock(name="mw3")
         mw3.machine = self.mock_machine3
-        # the repeated fourth one is the subordinate placeholder:
-        mw4 = MagicMock(name="mw4")
-        mock_machinewidget.side_effect = [mw1, mw2, mw3, mw4]
+        # the rest are the placeholders:
+        mw4 = MagicMock(name="mock_placeholder_widget1")
+        mw4.machine = self.pc.sub_placeholder
+        mw5 = MagicMock(name="mock_placeholder_widget2")
+        mw5.machine = self.pc.def_placeholder
+        mock_machinewidget.side_effect = [mw1, mw2, mw3, mw4, mw5]
 
         ml = MachinesList(self.pc, self.actions)
-        self.assertEqual(4, len(ml.machine_widgets))
+        self.assertEqual(5, len(ml.machine_widgets))
 
         ml.filter_string = "machine1-filter_label"
         ml.update()
@@ -342,14 +345,14 @@ class ServicesListTestCase(unittest.TestCase):
 
     def test_widgets_config(self, mock_servicewidgetclass):
         for show_constraints in [False, True]:
-            ServicesList(self.pc, self.actions, self.sub_actions,
-                         show_constraints=show_constraints)
-
+            sl = ServicesList(self.pc, self.actions, self.sub_actions,
+                              show_constraints=show_constraints)
             mock_servicewidgetclass.assert_any_call(
                 CharmNovaCompute,
                 self.pc,
                 self.actions,
-                show_constraints)
+                show_constraints,
+                show_placements=sl.show_placements)
             mock_servicewidgetclass.reset_mock()
 
     def test_no_machine_no_constraints(self, mock_servicewidgetclass):

--- a/tools/fast-run-single-status
+++ b/tools/fast-run-single-status
@@ -7,6 +7,7 @@
 # and you're running in the source tree
 
 import glob
+import logging
 import os
 import shutil
 import subprocess
@@ -14,9 +15,10 @@ import yaml
 
 from cloudinstall.utils import container_run, container_run_status
 
+logging.basicConfig(level=logging.DEBUG)
+
 startdir = os.getcwd()
 os.chdir("..")
-deb_name = glob.glob("openstack_0.99*all.deb")[0]
 
 with open(os.path.expanduser("~/.cloud-install/config.yaml")) as cfg_file:
     cfg = yaml.load(cfg_file)
@@ -27,7 +29,8 @@ os.chdir(startdir)
 subprocess.check_call("make deb", shell=True, stdout=subprocess.DEVNULL,
                       stderr=subprocess.DEVNULL)
 
-shutil.copy("../"+deb_name, os.path.expanduser("~/.cloud-install/"))
+deb_name = glob.glob("../openstack_0.99*all.deb")[0]
+shutil.copy(deb_name, os.path.expanduser("~/.cloud-install/"))
 
 print("removing old version")
 r = container_run(container_name, "sudo apt-get -y remove openstack")
@@ -36,7 +39,7 @@ print(r)
 print("installing in container")
 r = container_run(container_name,
                   'sudo dpkg -i /home/ubuntu/.cloud-install/{}'.format(
-                      deb_name))
+                      os.path.basename(deb_name)))
 
 print("r is {}".format(r))
 

--- a/tools/fast-run-single-status
+++ b/tools/fast-run-single-status
@@ -1,0 +1,45 @@
+#!/usr/bin/python3
+
+# a simple script to build and copy a new deb into an existing
+# container to test changes to openstack-status quickly.
+
+# assumes that you've got a running single install
+# and you're running in the source tree
+
+import glob
+import os
+import shutil
+import subprocess
+import yaml
+
+from cloudinstall.utils import container_run, container_run_status
+
+startdir = os.getcwd()
+os.chdir("..")
+deb_name = glob.glob("openstack_0.99*all.deb")[0]
+
+with open(os.path.expanduser("~/.cloud-install/config.yaml")) as cfg_file:
+    cfg = yaml.load(cfg_file)
+    container_name = cfg['container_name']
+
+print("building deb")
+os.chdir(startdir)
+subprocess.check_call("make deb", shell=True, stdout=subprocess.DEVNULL,
+                      stderr=subprocess.DEVNULL)
+
+shutil.copy("../"+deb_name, os.path.expanduser("~/.cloud-install/"))
+
+print("removing old version")
+r = container_run(container_name, "sudo apt-get -y remove openstack")
+print(r)
+
+print("installing in container")
+r = container_run(container_name,
+                  'sudo dpkg -i /home/ubuntu/.cloud-install/{}'.format(
+                      deb_name))
+
+print("r is {}".format(r))
+
+
+config_is_ignored = {}
+container_run_status(container_name, 'openstack-status', config_is_ignored)


### PR DESCRIPTION
Many changes.

- placement controller now tracks whether or not a service has been deployed.
- add-unit ui with separate queues replaced by new ui using same core.py deploy infrastructure as initial deploy
- placement UI refactored into several smaller files
- several refactorings for clarity and to remove dead code

NOTE:
tested well with single-install mode. I have not tested it in multi-install. 
@battlemidget: please give it a try on multi.