### PR TITLE
fix constraint arg

### DIFF
--- a/cloudinstall/charms/__init__.py
+++ b/cloudinstall/charms/__init__.py
@@ -184,7 +184,10 @@ export OS_REGION_NAME=RegionOne
         """ converts self.constraints into arg form for juju CLI"""
         args = []
         for k, v in self.constraints.items():
-            args.append("{}={}".format(k, ','.join(v)))
+            try:
+                args.append("{}={}".format(k, ','.join(v)))
+            except TypeError:
+                args.append("{}={}".format(k, v))
         all_args = " ".join(args)
         return "\"{}\"".format(all_args)
 


### PR DESCRIPTION
Fixes TypeError when deploying charms with constraints, previously hidden bug because glance-simplestreams-sync does not have constraints.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>