### PR TITLE
allow using the /next charms from openstack-charmers

### DIFF
--- a/bin/openstack-install
+++ b/bin/openstack-install
@@ -116,6 +116,9 @@ def parse_options(argv):
     parser.add_argument('--debug', action='store_true',
                         dest='debug',
                         help='Debug mode')
+    parser.add_argument('--next-charms', dest='next_charms',
+                        action='store_true',
+                        help="Use /next charms to test upcoming features.")
     # TODO: currently only works for single installs. Use
     # SHOW_JUJU_LOGS=1 in the env to enable. See github issue #421
     # parser.add_argument('--show-logs', action='store_true',

--- a/cloudinstall/charms/__init__.py
+++ b/cloudinstall/charms/__init__.py
@@ -216,6 +216,10 @@ export OS_REGION_NAME=RegionOne
         if self.charm_rev:
             _charm_name_rev = "{}-{}".format(self.charm_name, self.charm_rev)
 
+        if self.config.getopt('next_charms'):
+            _charm_name_rev = ("cs:~openstack-charmers/charms/trusty/{}"
+                               "/next".format(self.charm_name))
+
         if self.subordinate:
             assert(num_units is None)
             num_units = 0

--- a/cloudinstall/charms/__init__.py
+++ b/cloudinstall/charms/__init__.py
@@ -261,6 +261,7 @@ export OS_REGION_NAME=RegionOne
         return False
 
     def bzr_get(self, branch_name):
+        self.ui.status_info_message("BZR branching '{}'".format(branch_name))
         localrepo = os.path.join(self.config.cfg_path,
                                  'local-charms',
                                  'trusty', self.charm_name)
@@ -295,8 +296,11 @@ export OS_REGION_NAME=RegionOne
             cmd += ' --config ' + CHARM_CONFIG_FILENAME
 
         try:
-            log.debug("Deploying {} from local: {}".format(self.charm_name,
-                                                           cmd))
+            infostr = ("Deploying {} from local: {}".format(self.charm_name,
+                                                            cmd))
+            log.debug(infostr)
+            self.ui.status_info_message(infostr)
+
             cmd_output = subprocess.check_output(cmd, stderr=subprocess.STDOUT,
                                                  shell=True)
 


### PR DESCRIPTION
Add support for --next-charms, which pulls the current stable unreleased openstack charms.