### PR TITLE
Remove install type from password dialog box title

### DIFF
--- a/cloudinstall/install.py
+++ b/cloudinstall/install.py
@@ -58,8 +58,7 @@ class InstallController:
     def _set_install_type(self, install_type):
         self.install_type = install_type
         self.ui.show_password_input(
-            'Create a new Openstack Password for %s install'.format(
-                self.install_type), self._save_password)
+            'Create a New OpenStack Password', self._save_password)
 
     def _save_password(self, creds):
         """ Checks passwords match and proceeds
@@ -77,8 +76,7 @@ class InstallController:
             self.ui.flash('Passwords did not match')
             self.loop.redraw_screen()
             return self.ui.show_password_input(
-                'Create a new Openstack Password for %s install'.format(
-                    self.install_type), self._save_password)
+                'Create a New OpenStack Password', self._save_password)
 
     def _save_maas_creds(self, creds):
         self.ui.hide_widget_on_top()


### PR DESCRIPTION
using %s and .format() doesn't work, the result was oddly no exception but also no string shown in the title

after fixing that I noticed that the title wrapped across more than one line and looked weird. trying to fix that made urwid burp on smaller screens so I gave up.

My argument for giving up being OK is that although it's nice to have context, it's not totally necessary in the title box there. :shrug: 

I'm open to arguments that we should try harder to fix this...

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>