### PR TITLE
Make cancel button in add-unit UI actually work

### DIFF
--- a/cloudinstall/core.py
+++ b/cloudinstall/core.py
@@ -90,7 +90,8 @@ class Controller:
             self.ui.render_node_install_wait(message="Waiting...")
             interval = self.config.node_install_wait_interval
         elif current_state == ControllerState.ADD_SERVICES:
-            self.ui.render_add_services_dialog(self.deploy_new_services)
+            self.ui.render_add_services_dialog(self.deploy_new_services,
+                                               self.cancel_add_services)
         elif current_state == ControllerState.SERVICES:
             self.update_node_states()
         else:
@@ -654,6 +655,16 @@ class Controller:
         self.wait_for_deployed_services_ready()
         self.set_unique_hostnames()
         self.enqueue_deployed_charms()
+
+    def cancel_add_services(self):
+        """User cancelled add-services screen.
+        Just redisplay services view.
+        """
+        self.config.setopt('current_state',
+                           ControllerState.SERVICES.value)
+        self.ui.render_services_view(self.nodes, self.juju_state,
+                                     self.maas_state, self.config)
+        self.loop.redraw_screen()
 
     def start(self):
         """ Starts UI loop

--- a/cloudinstall/gui.py
+++ b/cloudinstall/gui.py
@@ -705,9 +705,13 @@ class PegasusGUI(WidgetWrap):
         self.machine_wait_view.update()
         self.frame.body = self.machine_wait_view
 
-    def render_add_services_dialog(self, deploy_cb):
+    def render_add_services_dialog(self, deploy_cb, cancel_cb):
         def reset():
             self.add_services_dialog = None
+
+        def cancel():
+            reset()
+            cancel_cb()
 
         def deploy():
             reset()
@@ -716,7 +720,7 @@ class PegasusGUI(WidgetWrap):
         if self.add_services_dialog is None:
             self.add_services_dialog = AddServicesDialog(self.controller,
                                                          deploy_cb=deploy,
-                                                         cancel_cb=reset)
+                                                         cancel_cb=cancel)
         self.add_services_dialog.update()
         self.frame.body = Filler(self.add_services_dialog)
 


### PR DESCRIPTION
Cancel worked when it was an overlay and I didn't test it after I made it a full ControllerState.
Needed to make a cancel callback that switched states and redrew.

Works now.