### PR TITLE
Add resize_rootfs: False to top level container cloud-init userdata.

### DIFF
--- a/share/templates/userdata.yaml
+++ b/share/templates/userdata.yaml
@@ -80,6 +80,7 @@ password: ubuntu
 chpasswd: { expire: False }
 ssh_pwauth: True
 manage_etc_hosts: localhost
+resize_rootfs: False
 
 
 # Make sure we load our modules on first creation


### PR DESCRIPTION
Avoids things like trying to resize / using btrfs, which will fail inside a container.
Fixes #586.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>