### PR TITLE
Remove --storage CLI option. Add-unit dialog should be used instead.

### DIFF
--- a/bin/openstack-install
+++ b/bin/openstack-install
@@ -110,10 +110,6 @@ def parse_options(argv):
     parser.add_argument('--headless', action='store_true',
                         help="Run deployment without prompts/gui",
                         dest='headless')
-    parser.add_argument('--storage', dest='storage_backend',
-                        default='none',
-                        choices=['ceph', 'swift', 'none'],
-                        help="Choose storage backend to deploy initially.")
     parser.add_argument('--debug', action='store_true',
                         dest='debug',
                         help='Debug mode')

--- a/cloudinstall/placement/controller.py
+++ b/cloudinstall/placement/controller.py
@@ -472,8 +472,8 @@ class PlacementController:
             return b_charm.charm_name in a_charm.depends
 
         required_charms = [c for c in self.charm_classes()
-                           if c.is_core or
-                           c.charm_name in self.selected_storage_charms()]
+                           if c.is_core]
+
         planned_or_deployed = (self.assigned_charm_classes() +
                                required_charms +
                                self.deployed_charm_classes())
@@ -635,20 +635,6 @@ class PlacementController:
         import pprint
         log.debug(pprint.pformat(assignments))
         return assignments
-
-    def selected_storage_charms(self):
-        """returns minimal list of charm names that are required by user
-        selection. Other requirements are sorted using deps and
-        conflicts.
-        """
-        selected_backend = self.config.getopt('storage_backend')
-        if selected_backend == 'none':
-            return []
-        if selected_backend == 'ceph':
-            return ['ceph']
-        if selected_backend == 'swift':
-            return ['swift-proxy', 'swift-storage']
-        raise Exception("unexpected backend: {}".format(selected_backend))
 
     def gen_single(self):
         """Generates an assignment for the single installer."""

--- a/docs/openstack-config.md
+++ b/docs/openstack-config.md
@@ -44,10 +44,6 @@ Ubuntu OpenStack Installer configuration file
 
     Type of installation, choices: Single, Multi, Landscape OpenStack Autopilot
 
-**storage_backend**
-
-    Type of storage to use, default: none, choices: ceph, swift, none
-
 **upstream_deb**
 
     Provide an upstream openstack debian package, mostly used during development to

--- a/share/templates/charmconf.yaml
+++ b/share/templates/charmconf.yaml
@@ -60,11 +60,7 @@ heat:
 cinder:
   glance-api-version: 2
   openstack-origin: {{openstack_origin}}
-{% if storage_backend == 'ceph' %}
-  block-device: None
-{% else %}
   block-device: /var/lib/cinder-sdb.img|5G
-{% endif %}
 {% if openstack_tip is defined %}
   openstack-origin-git: "{{ render_tip_repo('cinder') }}"
 {% endif %}

--- a/test/test_placement_ui.py
+++ b/test/test_placement_ui.py
@@ -82,7 +82,6 @@ class ServiceWidgetTestCase(unittest.TestCase):
             utils.spew(tempf.name, yaml.dump(dict()))
             self.conf = Config({}, tempf.name)
 
-        self.conf.setopt('storage_backend', 'none')
         self.pc = PlacementController(self.mock_maas_state,
                                       self.conf)
 
@@ -329,7 +328,6 @@ class ServicesListTestCase(unittest.TestCase):
             utils.spew(tempf.name, yaml.dump(dict()))
             self.conf = Config({}, tempf.name)
 
-        self.conf.setopt('storage_backend', 'none')
         self.pc = PlacementController(self.mock_maas_state,
                                       self.conf)
         self.mock_machine = make_fake_machine('machine1', {'cpu_count': 3})


### PR DESCRIPTION
Removes --storage, now the only supported way to choose your storage backend is via the add-unit dialog, which can handle the complexity of which required/optional charms you want.

There's one issue - the cinder charmconf template checked this flag and can't do the equivalent once it's gone.
I think I've put in an adequate workaround, but please see my comment here for details: https://github.com/Ubuntu-Solutions-Engineering/openstack-installer/issues/540#issuecomment-102544344

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>