### PR TITLE
Add support for specifying an APT caching proxy, for e.g. apt-cacher-ng

### DIFF
--- a/bin/openstack-install
+++ b/bin/openstack-install
@@ -103,6 +103,10 @@ def parse_options(argv):
     parser.add_argument('--upstream-deb', dest='upstream_deb',
                         help='Upload a local copy of openstack debian package '
                         'to be used in a single install. (DEVELOPERS)')
+    parser.add_argument('--apt-proxy', dest='apt_proxy',
+                        help='Specify APT proxy')
+    parser.add_argument('--apt-https-proxy', dest='apt_https_proxy',
+                        help='Specify APT HTTPS proxy')
     parser.add_argument('--http-proxy', dest='http_proxy',
                         help='Specify HTTP proxy')
     parser.add_argument('--https-proxy', dest='https_proxy',

--- a/cloudinstall/config.py
+++ b/cloudinstall/config.py
@@ -31,6 +31,7 @@ INSTALL_TYPE_LANDSCAPE = ("Landscape OpenStack Autopilot",
                           "The Canonical Distribution "
                           "- Enterprise Openstack Install and Management.")
 
+
 class ConfigException(Exception):
     pass
 

--- a/cloudinstall/single_install.py
+++ b/cloudinstall/single_install.py
@@ -75,7 +75,18 @@ class SingleInstall:
 
         render_parts['seed_command'] = self._proxy_pollinate()
 
-        for opt in ['http_proxy', 'https_proxy', 'no_proxy',
+        apt_proxy = self.config.getopt('apt_proxy')
+        http_proxy = self.config.getopt('http_proxy')
+        if not apt_proxy and http_proxy:
+            self.config.setopt('apt_proxy', http_proxy)
+
+        apt_https_proxy = self.config.getopt('apt_https_proxy')
+        https_proxy = self.config.getopt('https_proxy')
+        if not apt_https_proxy and https_proxy:
+            self.config.setopt('apt_https_proxy', https_proxy)
+
+        for opt in ['apt_proxy', 'apt_https_proxy', 'http_proxy',
+                    'https_proxy', 'no_proxy',
                     'image_metadata_url', 'tools_metadata_url',
                     'apt_mirror']:
             val = self.config.getopt(opt)

--- a/cloudinstall/single_install.py
+++ b/cloudinstall/single_install.py
@@ -51,6 +51,18 @@ class SingleInstall:
         # Sets install type
         self.config.setopt('install_type', 'Single')
 
+    def setup_apt_proxy(self):
+        "Use http_proxy unless apt_proxy is explicitly set"
+        apt_proxy = self.config.getopt('apt_proxy')
+        http_proxy = self.config.getopt('http_proxy')
+        if not apt_proxy and http_proxy:
+            self.config.setopt('apt_proxy', http_proxy)
+
+        apt_https_proxy = self.config.getopt('apt_https_proxy')
+        https_proxy = self.config.getopt('https_proxy')
+        if not apt_https_proxy and https_proxy:
+            self.config.setopt('apt_https_proxy', https_proxy)
+
     def _proxy_pollinate(self):
         """ Proxy pollinate if http/s proxy is set """
         # pass proxy through to pollinate
@@ -75,16 +87,6 @@ class SingleInstall:
 
         render_parts['seed_command'] = self._proxy_pollinate()
 
-        apt_proxy = self.config.getopt('apt_proxy')
-        http_proxy = self.config.getopt('http_proxy')
-        if not apt_proxy and http_proxy:
-            self.config.setopt('apt_proxy', http_proxy)
-
-        apt_https_proxy = self.config.getopt('apt_https_proxy')
-        https_proxy = self.config.getopt('https_proxy')
-        if not apt_https_proxy and https_proxy:
-            self.config.setopt('apt_https_proxy', https_proxy)
-
         for opt in ['apt_proxy', 'apt_https_proxy', 'http_proxy',
                     'https_proxy', 'no_proxy',
                     'image_metadata_url', 'tools_metadata_url',
@@ -108,11 +110,11 @@ class SingleInstall:
                         'ubuntu_series':
                         self.config.getopt('ubuntu_series')}
 
-        if self.config.getopt('http_proxy'):
-            render_parts['http_proxy'] = self.config.getopt('http_proxy')
-
-        if self.config.getopt('https_proxy'):
-            render_parts['https_proxy'] = self.config.getopt('https_proxy')
+        for opt in ['apt_proxy', 'apt_https_proxy', 'http_proxy',
+                    'https_proxy']:
+            val = self.config.getopt(opt)
+            if val:
+                render_parts[opt] = val
 
         # configure juju environment for bootstrap
         single_env = utils.load_template('juju-env/single.yaml')
@@ -388,6 +390,8 @@ class SingleInstall:
                             "not found.".format(upstream_deb))
 
         utils.ssh_genkey()
+
+        self.setup_apt_proxy()
 
         self.prep_userdata()
 

--- a/share/templates/juju-env/single.yaml
+++ b/share/templates/juju-env/single.yaml
@@ -9,10 +9,11 @@ environments:
     network-bridge: lxcbr0
     default-series: {{ubuntu_series}}
     admin-secret: "{{openstack_password}}"
-{%- if http_proxy %}
-    apt-http-proxy: {{http_proxy}}
-{%- else %}
-    apt-http-proxy: 'http://{{maas_server}}:8000/'
+{%- if apt_proxy %}
+    apt-http-proxy: {{apt_proxy}}
+{%- endif %}
+{%- if apt_https_proxy %}
+    apt-https-proxy: {{apt_https_proxy}}
 {%- endif %}
 {%- if http_proxy %}
     http-proxy: {{http_proxy}}

--- a/share/templates/userdata.yaml
+++ b/share/templates/userdata.yaml
@@ -19,11 +19,11 @@ packages:
 groups:
   - libvirtd: [ubuntu]
   - sudo: [ubuntu]
-{%- if http_proxy %}
-apt_proxy: {{ http_proxy }}
+{%- if apt_proxy %}
+apt_proxy: {{ apt_proxy }}
 {%- endif %}
-{%- if https_proxy %}
-apt_https_proxy: {{ https_proxy }}
+{%- if apt_https_proxy %}
+apt_https_proxy: {{ apt_https_proxy }}
 {%- endif %}
 apt_get_wrapper:
   command: eatmydata


### PR DESCRIPTION
Allows you to point the installer at an existing apt proxy.
only applies to single installs.
If you have a fast caching proxy, this will use it for the container creation. 

## wait this isn't done yet
**WIP** It should also use it for the juju-created images but the juju env wasn't right. fixing that now

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/613)
<!-- Reviewable:end -->
