### PR TITLE
Remove misleading username/pass for MAAS

### DIFF
--- a/cloudinstall/placement/ui/__init__.py
+++ b/cloudinstall/placement/ui/__init__.py
@@ -247,8 +247,7 @@ class MachinesColumn(WidgetWrap):
 
         bc = self.placement_view.config.juju_env['bootstrap-config']
         maasname = "'{}' <{}>".format(bc['name'], bc['maas-server'])
-        maastitle = "Connected to MAAS {} l:root p:{}".format(
-            maasname, self.placement_view.config.getopt('openstack_password'))
+        maastitle = "Connected to MAAS {}".format(maasname)
         tw = Columns([Text(maastitle),
                       Padding(self.open_maas_button, align='right',
                               width=BUTTON_SIZE, right=2)])


### PR DESCRIPTION
The default values shown are only true if the installer creates your MAAS for you.
Since that's no longer a well-supported path, the shown values are almost always wrong.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/621)
<!-- Reviewable:end -->
