### PR TITLE
Avoid a crash by checking for None from yaml.load

### DIFF
--- a/cloudinstall/utils.py
+++ b/cloudinstall/utils.py
@@ -138,7 +138,9 @@ def populate_config(opts):
         presaved_config = os.path.join(
             install_home(), '.cloud-install/config.yaml')
         if os.path.exists(presaved_config):
-            cfg.update(yaml.load(slurp(presaved_config)))
+            config_d = yaml.load(slurp(presaved_config))
+            if config_d is not None:
+                cfg.update(config_d)
         scrub = sanitize_config_items(cfg_cli_opts)
         verbose_update(cfg, 'pre-existing config file',
                        scrub, 'command-line options')


### PR DESCRIPTION
If config.yaml exists but is empty, yaml.load returns None, which we
    try to use to update a dict, which throws an exception, which is
    not caught or printed and we bail

this is frustrating because it doesn't print an error.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/623)
<!-- Reviewable:end -->
