### PR TITLE
Fix openstack-origin-git from behind a proxy

### DIFF
--- a/cloudinstall/charms/__init__.py
+++ b/cloudinstall/charms/__init__.py
@@ -22,6 +22,7 @@ import os
 import sys
 import yaml
 from queue import Queue
+import shutil
 import subprocess
 import time
 import requests
@@ -284,10 +285,13 @@ export OS_REGION_NAME=RegionOne
         log.debug("{}: branching {} into dir {}".format(self.charm_name,
                                                         branch_name,
                                                         localrepo))
+
+        shutil.rmtree(os.path.join(self.config.cfg_path, 'local-charms'))
         os.makedirs(localrepo, exist_ok=True)
         try:
             subprocess.check_output(['bzr', 'co', '--lightweight',
-                                     branch_name, localrepo])
+                                     branch_name, localrepo],
+                                    stderr=subprocess.STDOUT)
         except Exception as e:
             log.warning("error checking out charm: "
                         "rc={} out={}".format(e.returncode,

--- a/cloudinstall/charms/__init__.py
+++ b/cloudinstall/charms/__init__.py
@@ -286,7 +286,8 @@ export OS_REGION_NAME=RegionOne
                                                         branch_name,
                                                         localrepo))
 
-        shutil.rmtree(os.path.join(self.config.cfg_path, 'local-charms'))
+        shutil.rmtree(os.path.join(self.config.cfg_path, 'local-charms'),
+                      ignore_errors=True)
         os.makedirs(localrepo, exist_ok=True)
         try:
             subprocess.check_output(['bzr', 'co', '--lightweight',

--- a/cloudinstall/utils.py
+++ b/cloudinstall/utils.py
@@ -282,6 +282,15 @@ def render_charm_config(config):
     if config.is_single():
         template_args['worker_multiplier'] = '1'
 
+    # add http proxy settings - should not be necessary as juju sets
+    # these in the charm execution environment, but required for
+    # openstack-origin-git. See: https://launchpad.net/bugs/1472357
+
+    for pk in ['http_proxy', 'https_proxy']:
+        pv = config.getopt(pk)
+        if pv:
+            template_args[pk] = pv
+
     charm_conf_modified = charm_conf.render(**template_args)
     dest_yaml_path = os.path.join(config.cfg_path, 'charmconf.yaml')
     spew(dest_yaml_path, charm_conf_modified)

--- a/share/templates/charmconf.yaml
+++ b/share/templates/charmconf.yaml
@@ -10,11 +10,11 @@ keys if there are no values for them.
 {% macro render_tip_repo(service) %}
 {repositories: [
  {name: requirements,
-  repository: 'git://git.openstack.org/openstack/requirements',
+  repository: 'git://github.com/openstack/requirements',
   branch: stable/{{openstack_release}}
  },
  {name: {{service}},
-  repository: 'git://git.openstack.org/openstack/{{ service }}',
+  repository: 'git://github.com/openstack/{{ service }}',
   branch: stable/{{openstack_release}}
  }
 ],

--- a/share/templates/charmconf.yaml
+++ b/share/templates/charmconf.yaml
@@ -17,7 +17,14 @@ keys if there are no values for them.
   repository: 'git://git.openstack.org/openstack/{{ service }}',
   branch: stable/{{openstack_release}}
  }
-]}
+],
+{%- if http_proxy is defined %}
+http_proxy: '{{http_proxy}}',
+{%- endif %}
+{%- if https_proxy is defined %}
+https_proxy: '{{https_proxy}}'
+{%- endif %}
+}
 {%- endmacro %}
 
 {%- macro render_tip_neutron() %}
@@ -43,8 +50,12 @@ keys if there are no values for them.
   branch: stable/{{openstack_release}}
  }
 ],
-http_proxy: 'http://squid.internal:3128',
-https_proxy: 'http://squid.internal:3128'
+{%- if http_proxy is defined %}
+http_proxy: '{{http_proxy}}',
+{%- endif %}
+{%- if https_proxy is defined %}
+https_proxy: '{{https_proxy}}'
+{%- endif %}
 }
 {%- endmacro %}
 


### PR DESCRIPTION
We can't use http urls in openstack-origin-git, so we just point everything at github.com because some firewalls (like canonical's internal) have a special rule allowing git connections to github but denying that port elsewhere.

The better fix would be to simply use http:// for the git urls so they'd go through your proxy, which would work fine except for a bug in charmhelpers: https://launchpad.net/bugs/1472416

We can revisit once that's fixed in charmhelpers

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/633)
<!-- Reviewable:end -->
