### PR TITLE
Use http repo urls so http proxy settings are used.

### DIFF
--- a/share/templates/charmconf.yaml
+++ b/share/templates/charmconf.yaml
@@ -10,11 +10,11 @@ keys if there are no values for them.
 {% macro render_tip_repo(service) %}
 {repositories: [
  {name: requirements,
-  repository: 'git://github.com/openstack/requirements',
+  repository: 'http://github.com/openstack/requirements',
   branch: stable/{{openstack_release}}
  },
  {name: {{service}},
-  repository: 'git://github.com/openstack/{{ service }}',
+  repository: 'http://github.com/openstack/{{ service }}',
   branch: stable/{{openstack_release}}
  }
 ],
@@ -30,23 +30,23 @@ https_proxy: '{{https_proxy}}'
 {%- macro render_tip_neutron() %}
 {repositories: [
  {name: requirements,
-  repository: 'git://github.com/openstack/requirements',
+  repository: 'http://github.com/openstack/requirements',
   branch: stable/{{openstack_release}}
  },
  {name: neutron-fwaas,
-  repository: 'git://github.com/openstack/neutron-fwaas',
+  repository: 'http://github.com/openstack/neutron-fwaas',
   branch: stable/{{openstack_release}}
  },
  {name: neutron-lbaas,
-  repository: 'git://github.com/openstack/neutron-lbaas',
+  repository: 'http://github.com/openstack/neutron-lbaas',
   branch: stable/{{openstack_release}}
  },
  {name: neutron-vpnaas,
-  repository: 'git://github.com/openstack/neutron-vpnaas',
+  repository: 'http://github.com/openstack/neutron-vpnaas',
   branch: stable/{{openstack_release}}
  },
  {name: neutron,
-  repository: 'git://github.com/openstack/neutron',
+  repository: 'http://github.com/openstack/neutron',
   branch: stable/{{openstack_release}}
  }
 ],


### PR DESCRIPTION
The charms do in fact do the right thing with http repo urls, so use them so we can go thru the proxy

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/636)
<!-- Reviewable:end -->
