### PR TITLE
Ensure that nested KVM is enabled for single

### DIFF
--- a/debian/openstack.modprobe
+++ b/debian/openstack.modprobe
@@ -1,0 +1,1 @@
+options kvm_intel nested=1


### PR DESCRIPTION
Attempts to check if the kvm_intel nested param is ON for single
installs, which require nested containers to start any Nova VMs.

If the system has qemu-system-x86 installed, it will probably be ON,
because that package installs a /etc/modprobe.d/qemu-system-x86.conf
file to set it. If not, the default is OFF for kvm_intel. kvm_amd is
default ON.

Adds a modprobe.d/openstack.conf file using dh_installmodules to keep
the setting thru reboots.

Tries to reload the kvm_intel kernel module to pick up the new
modprobe.d settings.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/638)
<!-- Reviewable:end -->
