### PR TITLE
Keep local charm branches around

### DIFF
--- a/cloudinstall/charms/__init__.py
+++ b/cloudinstall/charms/__init__.py
@@ -286,8 +286,7 @@ export OS_REGION_NAME=RegionOne
                                                         branch_name,
                                                         localrepo))
 
-        shutil.rmtree(os.path.join(self.config.cfg_path, 'local-charms'),
-                      ignore_errors=True)
+        shutil.rmtree(localrepo, ignore_errors=True)
         os.makedirs(localrepo, exist_ok=True)
         try:
             subprocess.check_output(['bzr', 'co', '--lightweight',


### PR DESCRIPTION
A previous commit removed the local repo to ensure that repeated deploys
will still work even if there was already a downloaded branch. This
restricts that to only remove the charm currently being downloaded, to
allow for later inspection.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/639)
<!-- Reviewable:end -->
