### PR TITLE
Start of install controller separations

### DIFF
--- a/bin/openstack-install
+++ b/bin/openstack-install
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- mode: python; -*-
 #
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -16,32 +16,24 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-""" CLI for creating lxc containers needed by the installer """
+""" CLI for installing Ubuntu OpenStack """
 
 import argparse
 import sys
 import os
 import logging
-import signal
 from functools import partial
 from cloudinstall.log import setup_logger
 import cloudinstall.utils as utils
 from cloudinstall.gui import PegasusGUI, InstallHeader
 from cloudinstall.consoleui import ConsoleUI
-from cloudinstall.install import InstallController
+from cloudinstall.controllers.installbase import InstallController
 from cloudinstall.config import Config
 from cloudinstall.ev import EventLoop
 from cloudinstall import __version__ as version
 
 CFG_FILE = os.path.join(utils.install_home(),
                         '.cloud-install/config.yaml')
-
-
-def sig_handler(signum, frame):
-    sys.exit(1)
-
-for sig in (signal.SIGTERM, signal.SIGQUIT, signal.SIGINT, signal.SIGHUP):
-    signal.signal(sig, sig_handler)
 
 
 def parse_options(argv):
@@ -172,7 +164,7 @@ if __name__ == '__main__':
 
     try:
         setup_logger(headless=cfg.getopt('headless'))
-    except PermissionError:
+    except PermissionError:  # NOQA
         print("Permission error accessing log file.\n"
               "This probably indicates a broken partial install.\n"
               "Please use 'openstack-install -u' to uninstall, "
@@ -236,8 +228,12 @@ if __name__ == '__main__':
     # Choose event loop
     ev = EventLoop(ui, cfg, logger)
 
-    install = InstallController(
-        ui=ui, config=cfg, loop=ev)
+    try:
+        install = InstallController(
+            ui=ui, config=cfg, loop=ev)
+    except:
+        print("Unable to start install controller")
+        sys.exit(1)
 
     logger.info('Running {} release'.format(
                 cfg.getopt('openstack_release').capitalize()))

--- a/cloudinstall/controllers/__init__.py
+++ b/cloudinstall/controllers/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2015 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/cloudinstall/controllers/install/__init__.py
+++ b/cloudinstall/controllers/install/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2015 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from .single import SingleInstall  # NOQA
+from .landscape import LandscapeInstall  # NOQA
+from .multi import (MultiInstall, MultiInstallExistingMaas, LandscapeInstallFinal)  # NOQA

--- a/cloudinstall/controllers/install/landscape.py
+++ b/cloudinstall/controllers/install/landscape.py
@@ -1,5 +1,4 @@
-#
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -16,11 +15,11 @@
 
 import logging
 
-from cloudinstall.multi_install import (MultiInstall,
-                                        MultiInstallExistingMaas)
+from .multi import (MultiInstall,
+                    MultiInstallExistingMaas)
 
 
-log = logging.getLogger('cloudinstall.landscape_install')
+log = logging.getLogger('cloudinstall.c.i.landscape')
 
 
 class LandscapeInstall:
@@ -80,10 +79,7 @@ class LandscapeInstall:
 
     def run(self):
         if self.config.getopt('headless'):
-            if self.config.getopt('landscapecreds'):
-                self._do_install_existing_maas()
-            else:
-                self._do_install_new_maas()
+            self._do_install_existing_maas()
         else:
             self.display_controller.status_info_message(
                 "Please enter your Landscape information and "

--- a/cloudinstall/controllers/install/multi.py
+++ b/cloudinstall/controllers/install/multi.py
@@ -31,33 +31,7 @@ from cloudinstall.netutils import get_ip_set
 from cloudinstall import utils
 
 
-log = logging.getLogger('cloudinstall.multi_install')
-
-BRIDGE_MODIFIED_WARNING = """
-# WARNING: This file has been modified by openstack-install
-#
-# openstack-install redefines interfaces in
-# /etc/network/interfaces.d/openstack.cfg.
-# You must edit or remove /etc/network/interfaces.d/openstack.cfg if you
-# want to re-enable interfaces here.
-# See 'openstack-install -u', which will uninstall these changes.
-"""
-
-
-DNS_CONF_TEMPLATE = """
-options {{
-        directory "/var/cache/bind";
-        dnssec-validation auto;
-
-        forwarders {{
-        {}
-        }};
-
-        include "/etc/bind/maas/named.conf.options.inside.maas";
-        auth-nxdomain no;
-        listen-on-v6 {{ any; }};
-}};
-"""
+log = logging.getLogger('cloudinstall.c.i.multi')
 
 
 class MultiInstall:

--- a/cloudinstall/controllers/install/single.py
+++ b/cloudinstall/controllers/install/single.py
@@ -1,4 +1,3 @@
-#
 # Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
@@ -14,6 +13,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+""" Single Install Controller """
+
 from ipaddress import IPv4Network
 import logging
 import os
@@ -28,7 +29,7 @@ from cloudinstall.api.container import (Container,
                                         ContainerRunException)
 
 
-log = logging.getLogger('cloudinstall.single_install')
+log = logging.getLogger('cloudinstall.c.i.single')
 
 
 class SingleInstallException(Exception):

--- a/cloudinstall/controllers/installbase.py
+++ b/cloudinstall/controllers/installbase.py
@@ -1,4 +1,3 @@
-#
 # Copyright 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
@@ -21,10 +20,11 @@ from cloudinstall.config import (INSTALL_TYPE_SINGLE,
                                  INSTALL_TYPE_MULTI,
                                  INSTALL_TYPE_LANDSCAPE)
 from cloudinstall.state import InstallState
-from cloudinstall.single_install import SingleInstall
-from cloudinstall.landscape_install import LandscapeInstall
-from cloudinstall.multi_install import MultiInstallExistingMaas
 import cloudinstall.utils as utils
+
+from cloudinstall.controllers.install import (SingleInstall,
+                                              LandscapeInstall,
+                                              MultiInstallExistingMaas)
 
 
 log = logging.getLogger('cloudinstall.install')
@@ -128,14 +128,10 @@ class InstallController:
             # TODO: Clean this up a bit more I dont like relying on
             # opts.headless but in a few places
             if self.config.getopt('headless'):
-                if self.config.getopt('maascreds'):
-                    self.ui.status_info_message(
-                        "Performing a Multi install with existing MAAS")
-                    self.MultiInstallExistingMaas(
-                        self.loop, self.ui, self.config).run()
-                else:
-                    self.MultiInstallNewMaas(
-                        self.loop, self.ui, self.config).run()
+                self.ui.status_info_message(
+                    "Performing a Multi install with existing MAAS")
+                self.MultiInstallExistingMaas(
+                    self.loop, self.ui, self.config).run()
             else:
                 self.ui.select_maas_type(self._save_maas_creds)
         elif self.install_type == INSTALL_TYPE_LANDSCAPE[0]:

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -52,15 +52,14 @@ class InstallControllerTestCase(unittest.TestCase):
         ui = StubUI()
         self.controller = InstallController(ui=ui)
 
-    @patch('cloudinstall.single_install.SingleInstall')
+    @patch('cloudinstall.controllers.install.SingleInstall')
     def test_do_install_single_openstack_release(self, SingleInstall):
         """do_install will set the OpenStack release for Single"""
         self.controller.SingleInstall = SingleInstall
         self.controller.do_install("Single")
         self.assertEqual(self.controller.ui.release, "Icehouse (2014.1.3)")
 
-    @patch('cloudinstall.multi_install.MultiInstallNewMaas')
-    @patch('cloudinstall.multi_install.MultiInstallExistingMaas')
+    @patch('cloudinstall.controllers.install.MultiInstallExistingMaas')
     def test_do_install_multi_openstack_release(
             self, MultiInstallNewMaas, MultiInstallExistingMaas):
         """do_install will set the OpenStack release for Multi"""
@@ -69,7 +68,7 @@ class InstallControllerTestCase(unittest.TestCase):
         self.controller.do_install("Multi")
         self.assertEqual(self.controller.ui.release, "Icehouse (2014.1.3)")
 
-    @patch('cloudinstall.landscape_install.LandscapeInstall')
+    @patch('cloudinstall.controllers.install.LandscapeInstall')
     def test_do_install_landscape_openstack_release(self, LandscapeInstall):
         """do_install will not set the OpenStack release for Landscape"""
         self.controller.LandscapeInstall = LandscapeInstall

--- a/test/test_landscape_install.py
+++ b/test/test_landscape_install.py
@@ -21,14 +21,15 @@ import logging
 import unittest
 from unittest.mock import ANY, MagicMock, patch, PropertyMock
 
-from cloudinstall.multi_install import LandscapeInstallFinal
+from cloudinstall.controllers.install import LandscapeInstallFinal
 from cloudinstall.config import Config
 from tempfile import NamedTemporaryFile
 
 log = logging.getLogger('cloudinstall.test_landscape_install')
 
 
-@patch('cloudinstall.multi_install.utils')  # mocks everything in utils
+# mocks everything in utils
+@patch('cloudinstall.controllers.install.multi.utils')
 class LandscapeInstallFinalTestCase(unittest.TestCase):
 
     def setUp(self):

--- a/test/test_multi_install.py
+++ b/test/test_multi_install.py
@@ -18,7 +18,7 @@
 import unittest
 from unittest.mock import MagicMock, patch, call
 
-from cloudinstall.multi_install import MultiInstall
+from cloudinstall.controllers.install import MultiInstall
 from cloudinstall.config import Config
 from tempfile import NamedTemporaryFile
 

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -87,7 +87,7 @@ class MultiInstallStateTestCase(unittest.TestCase):
             self.conf = Config({}, tempf.name)
         self.mock_ui = MagicMock(name='ui')
 
-    @patch('cloudinstall.multi_install.MultiInstall')
+    @patch('cloudinstall.controllers.install.MultiInstall')
     def test_do_install_sets_state(self, MultiInstall):
         """ Validate installstate in multi install """
         mi = MultiInstall(self.mock_ui, config=self.conf)

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ downloadcache = ~/cache/pip
 deps = -r{toxinidir}/requirements.txt
 commands =
     nosetests -v --with-cover --cover-package=cloudinstall test --cover-inclusive cloudinstall
-    coveralls
 
 [testenv:flake]
 commands = flake8 {posargs} cloudinstall test bin


### PR DESCRIPTION
This is the start of some re-organizing of code. This first bit is to place the actual install section into separated controller directories. Once this is done I will start further separating out what is considered 'controller' code versus 'view' code.

Once the controller/view code are in their respective places I will then tackle the async code to be easier managed and acted upon in case of error rather than relying on our global exec handler.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/652)
<!-- Reviewable:end -->
