### PR TITLE
Add --maas-tag to filter machines used

### DIFF
--- a/bin/openstack-status
+++ b/bin/openstack-status
@@ -67,6 +67,8 @@ def parse_options(argv):
                         help='Debug mode')
     parser.add_argument(
         '--version', action='version', version='%(prog)s {}'.format(version))
+    parser.add_argument('--maas-tag', dest='maas_tag',
+                        help="Only operate on machines in MAAS with this tag")
     return parser.parse_args(argv)
 
 if __name__ == '__main__':

--- a/cloudinstall/maas/__init__.py
+++ b/cloudinstall/maas/__init__.py
@@ -321,7 +321,7 @@ class MaasState:
                 return m
         return None
 
-    def machines(self, state=None):
+    def machines(self, state=None, tag=None):
         """Maas Machines
 
         :param state
@@ -332,9 +332,13 @@ class MaasState:
         :rtype: list of MaasMachine
 
         """
+        nodes = [n for n in self.nodes()
+                 if n['hostname'] != 'juju-bootstrap.maas']
 
-        all_machines = [MaasMachine(-1, m) for m in self.nodes()
-                        if m['hostname'] != 'juju-bootstrap.maas']
+        if tag:
+            nodes = [n for n in nodes if tag in n['tag_names']]
+
+        all_machines = [MaasMachine(-1, m) for m in nodes]
         if state:
             return [m for m in all_machines if m.status == state]
         else:

--- a/cloudinstall/placement/controller.py
+++ b/cloudinstall/placement/controller.py
@@ -266,7 +266,7 @@ class PlacementController:
         are excluded.
         """
         if self.maas_state:
-            ms = self.maas_state.machines()
+            ms = self.maas_state.machines(tag=self.config.getopt('maas_tag'))
         else:
             ms = self._machines
 
@@ -587,7 +587,7 @@ class PlacementController:
         assignments = defaultdict(lambda: defaultdict(list))
 
         if maas_machines is None:
-            maas_machines = self.maas_state.machines(MaasMachineStatus.READY)
+            maas_machines = self.maas_state.machines(MaasMachineStatus.READY, tag=self.config.getopt('maas_tag'))
 
         def satisfying_machine(constraints):
             for machine in maas_machines:


### PR DESCRIPTION
Passing --maas-tag=foo will make the installer act as if the only
machines in MAAS are the ones with 'foo' as one of their tags.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/668)
<!-- Reviewable:end -->
