### PR TITLE
add constraints arg to control arch and tags of machines used for boo…

### DIFF
--- a/bin/openstack-install
+++ b/bin/openstack-install
@@ -119,8 +119,12 @@ def parse_options(argv):
                         default='trusty',
                         help="Ubuntu series codename (eg. 'trusty', 'utopic') "
                         "for juju default")
-    parser.add_argument('--maas-tag', dest='maas_tag',
-                        help="Only operate on machines in MAAS with this tag")
+    parser.add_argument('--constraints', dest='constraints',
+                        help="Constraints to pass to Juju to control what "
+                        "machines are used. A single string with key=value "
+                        "pairs separated by spaces. "
+                        "e.g. \"arch=amd64 tags=foo\". Also limits MAAS "
+                        "machines used for service placement.")
     parser.add_argument(
         '--version', action='version', version='%(prog)s {}'.format(version))
     return parser.parse_args(argv)

--- a/bin/openstack-status
+++ b/bin/openstack-status
@@ -67,8 +67,12 @@ def parse_options(argv):
                         help='Debug mode')
     parser.add_argument(
         '--version', action='version', version='%(prog)s {}'.format(version))
-    parser.add_argument('--maas-tag', dest='maas_tag',
-                        help="Only operate on machines in MAAS with this tag")
+    parser.add_argument('--constraints', dest='constraints',
+                        help="Constraints to pass to Juju to control what "
+                        "machines are used. A single string with key=value "
+                        "pairs separated by spaces. "
+                        "e.g. \"arch=amd64 tags=foo\". Also limits MAAS "
+                        "machines used for service placement.")
     return parser.parse_args(argv)
 
 if __name__ == '__main__':

--- a/cloudinstall/controllers/install/multi.py
+++ b/cloudinstall/controllers/install/multi.py
@@ -109,10 +109,14 @@ class MultiInstall:
             dbgflags = "--debug"
 
         bsflags = ""
-        #    bsflags = " --constraints tags=physical"
+
         bstarget = os.getenv("JUJU_BOOTSTRAP_TO")
         if bstarget:
             bsflags += " --to {}".format(bstarget)
+
+        cons = self.config.getopt('constraints')
+        if cons:
+            bsflags += " --constraints \"{}\"".format(cons)
 
         cmd = ("{0} juju {1} bootstrap {2}".format(
             self.config.juju_home(), dbgflags, bsflags))

--- a/cloudinstall/core.py
+++ b/cloudinstall/core.py
@@ -298,12 +298,15 @@ class Controller:
     def all_maas_machines_ready(self):
         self.maas_state.invalidate_nodes_cache()
 
+        cons = self.config.getopt('constraints')
         needed = set([m.instance_id for m in
                       self.placement_controller.machines_pending()])
         ready = set([m.instance_id for m in
-                     self.maas_state.machines(MaasMachineStatus.READY)])
+                     self.maas_state.machines(MaasMachineStatus.READY,
+                                              constraints=cons)])
         allocated = set([m.instance_id for m in
-                         self.maas_state.machines(MaasMachineStatus.ALLOCATED)
+                         self.maas_state.machines(MaasMachineStatus.ALLOCATED,
+                                                  constraints=cons)
                          ])
 
         summary = ", ".join(["{} {}".format(v, k) for k, v in

--- a/cloudinstall/machinewait.py
+++ b/cloudinstall/machinewait.py
@@ -70,7 +70,9 @@ class MachineWaitView(WidgetWrap):
     def get_status(self):
         " returns (global_ok, [ok, condition])"
         self.maas_state.invalidate_nodes_cache()
-        machines = self.maas_state.machines(state=MaasMachineStatus.READY)
+        cons = self.config.getopt('constraints')
+        machines = self.maas_state.machines(state=MaasMachineStatus.READY,
+                                            constraints=cons)
         powerable_machines = [m for m in machines if m.power_type is not None]
         n_powerable = len(powerable_machines)
 

--- a/cloudinstall/placement/controller.py
+++ b/cloudinstall/placement/controller.py
@@ -266,7 +266,8 @@ class PlacementController:
         are excluded.
         """
         if self.maas_state:
-            ms = self.maas_state.machines(tag=self.config.getopt('maas_tag'))
+            cons = self.config.getopt('constraints')
+            ms = self.maas_state.machines(constraints=cons)
         else:
             ms = self._machines
 
@@ -588,7 +589,8 @@ class PlacementController:
 
         if maas_machines is None:
             maas_machines = self.maas_state.machines(
-                MaasMachineStatus.READY, tag=self.config.getopt('maas_tag'))
+                MaasMachineStatus.READY,
+                constraints=self.config.getopt('constraints'))
 
         def satisfying_machine(constraints):
             for machine in maas_machines:

--- a/test/test_placement_controller.py
+++ b/test/test_placement_controller.py
@@ -459,10 +459,6 @@ class PlacementControllerTestCase(unittest.TestCase):
         pc = PlacementController(None, self.conf)
         self.assertRaises(PlacementError, pc.gen_defaults)
 
-    # FIXME: Not sure whats going on with this test, assume
-    # its from the maas-tag addition. Also not sure why
-    # it fails now and not in previous commit?
-    @unittest.skip
     def test_gen_defaults_uses_only_ready(self):
         """gen_defaults should only use ready machines"""
         mock_maas_state = MagicMock()
@@ -478,7 +474,7 @@ class PlacementControllerTestCase(unittest.TestCase):
         # follow-on calls are from calls to get_assignments and do
         # not affect machines used for defaults
         self.assertEqual(mock_maas_state.machines.mock_calls[0],
-                         call(MaasMachineStatus.READY))
+                         call(MaasMachineStatus.READY, constraints=False))
 
     def test_gen_single_backends(self):
         "gen_single has no storage backend by default"


### PR DESCRIPTION
…tstrap and deploys

Fixes #680 

now you do 'openstack-install --constraints "tags=barbazbat,thisonetoo arch=amd64" 

that will pass it directly thru to juju bootstrap, and also filter out the results from MAAS for the deployment/placement code in the same way juju does

Signed-off-by: Mike McCracken <mike.mccracken@canonical.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/684)
<!-- Reviewable:end -->
