### PR TITLE
openstack-config: write result with no newlines

### DIFF
--- a/bin/openstack-config
+++ b/bin/openstack-config
@@ -29,14 +29,14 @@ CFG_FILE = os.path.join(utils.install_home(),
 
 if __name__ == '__main__':
     if not os.path.isfile(CFG_FILE):
-        print("No existing config file found.")
+        sys.stderr.write("No existing config file found.\n")
         sys.exit(1)
     if len(sys.argv) > 2:
-        print("Only pass in 1 config item to query.")
+        sys.stderr.write("Only pass in 1 config item to query.\n")
         sys.exit(1)
     config_name = sys.argv[1]
     opts = argparse.Namespace(config_file=CFG_FILE)
     cfg = Config(utils.populate_config(opts))
     val = cfg.getopt(config_name)
-    print(val)
+    sys.stdout.write(str(val))
     sys.exit(0)


### PR DESCRIPTION
Users of this utility expect a string with no whitespace, as they often
assign it directly to a shell variable.

Note this solves a weird problem with the simplestreams-sync status listener not being able to get initial status - it tries to get juju_home from openstack-config, and ends up getting "~/.cloud-install/juju\n", which it then uses in a call to 'juju run', and that apparently causes juju to create that directory, which gets displayed in 'ls' as '~/.cloud-install/juju?'

I think it probably also caused some reports of unexpected error messages with the uninstall script in the single install case, where the container_network config var is used to pass to 'route del', and that having a newline in it might cause spurious messages.

Signed-off-by: Mike McCracken <mike.mccracken@canonical.com>