### PR TITLE
check if env is bootstrapped before destroying

### DIFF
--- a/bin/openstack-uninstall
+++ b/bin/openstack-uninstall
@@ -19,7 +19,14 @@ case $WHAT in
   Multi)
     echo Multi install environment
 
-    JUJU_HOME="$CFG_HOME/juju" juju destroy-environment --yes --force maas || exit 1
+    if [ `JUJU_HOME="$CFG_HOME/juju" juju status` ]; then
+	JUJU_HOME="$CFG_HOME/juju" juju destroy-environment --yes --force maas || \
+	    { echo "error in destroy-environment, exiting without further cleanup"
+	      exit 1
+	    }
+    else
+	echo "Environment not bootstrapped, continuing with other cleanup."
+    fi
 
     # Multi places backup network settings here.
     rm -rf /etc/openstack || true


### PR DESCRIPTION
This avoids https://bugs.launchpad.net/juju-core/+bug/1490865

Signed-off-by: Mike McCracken <mike.mccracken@canonical.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/687)
<!-- Reviewable:end -->
