### PR TITLE
Change --openstack-tip to --openstack-git-branch to allow getting master

### DIFF
--- a/bin/openstack-install
+++ b/bin/openstack-install
@@ -68,9 +68,14 @@ def parse_options(argv):
                         dest='openstack_release', default="kilo",
                         choices=['icehouse', 'juno', 'kilo', 'liberty'],
                         help="Specify a specific OpenStack release.")
-    parser.add_argument('--openstack-tip', action="store_true",
-                        dest='openstack_tip', default=False,
-                        help="Deploy from OpenStack master branches.")
+    parser.add_argument('--openstack-git-branch',
+                        choices=["master", "stable"],
+                        dest='openstack_git_branch', default=None,
+                        help="Specifies upstream git branch to clone for "
+                        "OpenStack services. Note that 'master' is just "
+                        " the branch 'master', while 'stable' is combined "
+                        " with the --openstack-release value, e.g."
+                        " 'stable/kilo'")
     parser.add_argument('-a', type=str, default=None,
                         help='<arch, ..> comma-separated list of '
                         'architectures to filter available cloud '

--- a/cloudinstall/utils.py
+++ b/cloudinstall/utils.py
@@ -229,11 +229,15 @@ def render_charm_config(config):
         install_type=config.getopt('install_type'),
         openstack_password=config.getopt('openstack_password'))
 
-    if config.getopt('openstack_tip'):
-        template_args['openstack_tip'] = config.getopt(
-            'openstack_tip')
-    template_args['openstack_release'] = config.getopt(
-        'openstack_release')
+    os_branch = config.getopt('openstack_git_branch')
+    os_release = config.getopt('openstack_release')
+    if os_branch:
+        if os_branch == 'master':
+            template_args['openstack_git_branch'] = os_branch
+        else:
+            template_args['openstack_git_branch'] = "{}/{}".format(os_branch,
+                                                                   os_release)
+    template_args['openstack_release'] = os_release
 
     ubuntu_series = config.getopt('ubuntu_series')
     openstack_release = config.getopt('openstack_release')

--- a/share/templates/charmconf.yaml
+++ b/share/templates/charmconf.yaml
@@ -11,11 +11,11 @@ keys if there are no values for them.
 {repositories: [
  {name: requirements,
   repository: 'http://github.com/openstack/requirements',
-  branch: stable/{{openstack_release}}
+  branch: {{openstack_git_branch}}
  },
  {name: {{service}},
   repository: 'http://github.com/openstack/{{ service }}',
-  branch: stable/{{openstack_release}}
+  branch: {{openstack_git_branch}}
  }
 ],
 {%- if http_proxy is defined %}
@@ -31,23 +31,23 @@ https_proxy: '{{https_proxy}}'
 {repositories: [
  {name: requirements,
   repository: 'http://github.com/openstack/requirements',
-  branch: stable/{{openstack_release}}
+  branch: {{openstack_git_branch}}
  },
  {name: neutron-fwaas,
   repository: 'http://github.com/openstack/neutron-fwaas',
-  branch: stable/{{openstack_release}}
+  branch: {{openstack_git_branch}}
  },
  {name: neutron-lbaas,
   repository: 'http://github.com/openstack/neutron-lbaas',
-  branch: stable/{{openstack_release}}
+  branch: {{openstack_git_branch}}
  },
  {name: neutron-vpnaas,
   repository: 'http://github.com/openstack/neutron-vpnaas',
-  branch: stable/{{openstack_release}}
+  branch: {{openstack_git_branch}}
  },
  {name: neutron,
   repository: 'http://github.com/openstack/neutron',
-  branch: stable/{{openstack_release}}
+  branch: {{openstack_git_branch}}
  }
 ],
 {%- if http_proxy is defined %}
@@ -72,7 +72,7 @@ cinder:
   glance-api-version: 2
   openstack-origin: {{openstack_origin}}
   block-device: /var/lib/cinder-sdb.img|5G
-{%- if openstack_tip is defined %}
+{%- if openstack_git_branch is defined %}
   openstack-origin-git: "{{ render_tip_repo('cinder') }}"
 {%- endif %}
 
@@ -98,7 +98,7 @@ glance:
 {%- if worker_multiplier is defined %}
   worker-multiplier: {{worker_multiplier}}
 {%- endif %}
-{%- if openstack_tip is defined %}
+{%- if openstack_git_branch is defined %}
   openstack-origin-git: "{{ render_tip_repo('glance') }}"
 {%- endif %}
 
@@ -115,7 +115,7 @@ keystone:
 {%- if worker_multiplier is defined %}
   worker-multiplier: {{worker_multiplier}}
 {%- endif %}
-{%- if openstack_tip is defined %}
+{%- if openstack_git_branch is defined %}
   openstack-origin-git: "{{ render_tip_repo('keystone') }}"
 {%- endif %}
 
@@ -124,7 +124,7 @@ mysql:
   max-connections: 25000
 
 neutron-openvswitch:
-{%- if openstack_tip is defined %}
+{%- if openstack_git_branch is defined %}
   openstack-origin-git: "{{ render_tip_neutron() }}"
 {%- endif %}
 
@@ -132,7 +132,7 @@ neutron-api:
   l2-population: False
   neutron-security-groups: True
   openstack-origin: {{openstack_origin}}
-{%- if openstack_tip is defined %}
+{%- if openstack_git_branch is defined %}
   openstack-origin-git: "{{ render_tip_neutron() }}"
 {%- endif %}
 
@@ -146,26 +146,26 @@ nova-cloud-controller:
 {%- if worker_multiplier is defined %}
   worker-multiplier: {{worker_multiplier}}
 {%- endif %}
-{%- if openstack_tip is defined %}
+{%- if openstack_git_branch is defined %}
   openstack-origin-git: "{{ render_tip_repo('nova') }}"
 {%- endif %}
 
 nova-compute:
   openstack-origin: {{openstack_origin}}
-{%- if openstack_tip is defined %}
+{%- if openstack_git_branch is defined %}
   openstack-origin-git: "{{ render_tip_repo('nova') }}"
 {%- endif %}
 
 openstack-dashboard:
   openstack-origin: {{openstack_origin}}
-{%- if openstack_tip is defined %}
+{%- if openstack_git_branch is defined %}
   openstack-origin-git: "{{ render_tip_repo('horizon') }}"
 {%- endif %}
 
 neutron-gateway:
   instance-mtu: 1400
   openstack-origin: {{openstack_origin}}
-{%- if openstack_tip is defined %}
+{%- if openstack_git_branch is defined %}
   openstack-origin-git: "{{ render_tip_neutron() }}"
 {%- endif %}
 


### PR DESCRIPTION
In some cases a stable branch isn't available yet, so we can use master instead.

Signed-off-by: Mike McCracken <mike.mccracken@canonical.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/690)
<!-- Reviewable:end -->
