### PR TITLE
Change have_nextbranch to available_sources

### DIFF
--- a/cloudinstall/charms/__init__.py
+++ b/cloudinstall/charms/__init__.py
@@ -110,7 +110,7 @@ class CharmBase:
     conflicts = []
     is_core = False
     contrib = False
-    have_nextbranch = False
+    available_sources = []
 
     def __init__(self, config, ui, juju, juju_state,
                  machine=None):
@@ -232,11 +232,17 @@ export OS_REGION_NAME=RegionOne
         else:
             current_series = 'trusty'
 
-        if self.config.getopt('next_charms') and self.have_nextbranch:
+        if self.config.getopt('next_charms') and 'next' \
+           in self.available_sources:
             self.bzr_get("lp:~openstack-charmers/charms/trusty/{}"
                          "/next".format(self.charm_name), current_series)
             self.local_deploy(machine_spec, current_series)
             return False
+
+        if 'charmstore' not in self.available_sources:
+            raise Exception("{} is not found in available "
+                            "sources: {}".format(self.charm_name,
+                                                 self.available_sources))
 
         # if --use-nclxd and not --next-charms, just download LTS charms
         if self.config.getopt('use_nclxd'):

--- a/cloudinstall/charms/ceilometer.py
+++ b/cloudinstall/charms/ceilometer.py
@@ -38,6 +38,6 @@ class CharmCeilometer(CharmBase):
                ('ceilometer:ceilometer-service',
                 'ceilometer-agent:ceilometer-service')]
     depends = ['ceilometer-agent', 'mongodb']
-    have_nextbranch = True
+    available_sources = ['charmstore', 'next']
 
 __charm_class__ = CharmCeilometer

--- a/cloudinstall/charms/ceilometer_agent.py
+++ b/cloudinstall/charms/ceilometer_agent.py
@@ -31,6 +31,6 @@ class CharmCeilometerAgent(CharmBase):
     contrib = True
     deploy_priority = 0
     depends = ['ceilometer']
-    have_nextbranch = True
+    available_sources = ['charmstore', 'next']
 
 __charm_class__ = CharmCeilometerAgent

--- a/cloudinstall/charms/ceph.py
+++ b/cloudinstall/charms/ceph.py
@@ -38,7 +38,7 @@ class CharmCeph(CharmBase):
     allow_multi_units = True
     constraints = {'mem': 1024,
                    'root-disk': 20480}
-    have_nextbranch = True
+    available_sources = ['charmstore', 'next']
 
     @classmethod
     def required_num_units(self):

--- a/cloudinstall/charms/ceph_osd.py
+++ b/cloudinstall/charms/ceph_osd.py
@@ -32,6 +32,6 @@ class CharmCephOSD(CharmBase):
                ('ntp:juju-info', 'ceph-osd:juju-info')]
     depends = ['ntp', 'ceph']
     isolate = True
-    have_nextbranch = True
+    available_sources = ['charmstore', 'next']
 
 __charm_class__ = CharmCephOSD

--- a/cloudinstall/charms/ceph_radosgw.py
+++ b/cloudinstall/charms/ceph_radosgw.py
@@ -32,6 +32,6 @@ class CharmCephRadosGw(CharmBase):
                 'keystone:identity-service')]
     depends = ['ceph']
     conflicts = ['swift-proxy', 'swift-storage']
-    have_nextbranch = True
+    available_sources = ['charmstore', 'next']
 
 __charm_class__ = CharmCephRadosGw

--- a/cloudinstall/charms/cinder.py
+++ b/cloudinstall/charms/cinder.py
@@ -41,6 +41,6 @@ class CharmCinder(CharmBase):
 
     allowed_assignment_types = [AssignmentType.BareMetal,
                                 AssignmentType.KVM]
-    have_nextbranch = True
+    available_sources = ['charmstore', 'next']
 
 __charm_class__ = CharmCinder

--- a/cloudinstall/charms/cinder_ceph.py
+++ b/cloudinstall/charms/cinder_ceph.py
@@ -30,6 +30,6 @@ class CharmCinderCeph(CharmBase):
     deploy_priority = 5
     subordinate = True
     depends = ['ceph', 'cinder']
-    have_nextbranch = True
+    available_sources = ['charmstore', 'next']
 
 __charm_class__ = CharmCinderCeph

--- a/cloudinstall/charms/compute.py
+++ b/cloudinstall/charms/compute.py
@@ -49,6 +49,6 @@ class CharmNovaCompute(CharmBase):
     allowed_assignment_types = [AssignmentType.BareMetal,
                                 AssignmentType.KVM]
     is_core = True
-    have_nextbranch = True
+    available_sources = ['charmstore', 'next']
 
 __charm_class__ = CharmNovaCompute

--- a/cloudinstall/charms/controller.py
+++ b/cloudinstall/charms/controller.py
@@ -39,7 +39,7 @@ class CharmNovaCloudController(CharmBase):
                 'nova-cloud-controller:identity-service')]
     allow_multi_units = False
     is_core = True
-    have_nextbranch = True
+    available_sources = ['charmstore', 'next']
 
     def post_proc(self):
         """ post processing for nova-cloud-controller """

--- a/cloudinstall/charms/glance.py
+++ b/cloudinstall/charms/glance.py
@@ -27,6 +27,6 @@ class CharmGlance(CharmBase):
                ('keystone:identity-service', 'glance:identity-service'),
                ('rabbitmq-server:amqp', 'glance:amqp')]
     is_core = True
-    have_nextbranch = True
+    available_sources = ['charmstore', 'next']
 
 __charm_class__ = CharmGlance

--- a/cloudinstall/charms/glance_simplestreams_sync.py
+++ b/cloudinstall/charms/glance_simplestreams_sync.py
@@ -46,6 +46,7 @@ class CharmGlanceSimplestreamsSync(CharmBase):
     related = [('keystone:identity-service',
                 'glance-simplestreams-sync:identity-service')]
     is_core = True
+    available_sources = ['charmstore', 'next']
 
     def download_stable(self):
         if not os.path.exists(CHARMS_DIR):

--- a/cloudinstall/charms/heat.py
+++ b/cloudinstall/charms/heat.py
@@ -31,6 +31,6 @@ class CharmHeat(CharmBase):
                ('rabbitmq-server:amqp',
                 'heat:amqp')]
     contrib = True
-    have_nextbranch = True
+    available_sources = ['charmstore']
 
 __charm_class__ = CharmHeat

--- a/cloudinstall/charms/horizon.py
+++ b/cloudinstall/charms/horizon.py
@@ -26,6 +26,6 @@ class CharmHorizon(CharmBase):
     related = [('keystone:identity-service',
                 'openstack-dashboard:identity-service')]
     is_core = True
-    have_nextbranch = True
+    available_sources = ['charmstore', 'next']
 
 __charm_class__ = CharmHorizon

--- a/cloudinstall/charms/jujugui.py
+++ b/cloudinstall/charms/jujugui.py
@@ -24,5 +24,6 @@ class CharmJujuGui(CharmBase):
     display_name = 'Juju GUI'
     display_priority = DisplayPriorities.Other
     deploy_priority = 1
+    available_sources = ['charmstore']
 
 __charm_class__ = CharmJujuGui

--- a/cloudinstall/charms/keystone.py
+++ b/cloudinstall/charms/keystone.py
@@ -31,7 +31,7 @@ class CharmKeystone(CharmBase):
     related = [('mysql:shared-db', 'keystone:shared-db')]
     deploy_priority = 1
     is_core = True
-    have_nextbranch = True
+    available_sources = ['charmstore', 'next']
 
     def _is_auth_url_valid(self):
         existing_yaml = yaml.load(slurp(self.config.juju_environments_path))

--- a/cloudinstall/charms/mongodb.py
+++ b/cloudinstall/charms/mongodb.py
@@ -26,5 +26,6 @@ class CharmMongo(CharmBase):
     display_name = 'MongoDB'
     deploy_priority = 0
     contrib = True
+    available_sources = ['charmstore']
 
 __charm_class__ = CharmMongo

--- a/cloudinstall/charms/mysql.py
+++ b/cloudinstall/charms/mysql.py
@@ -25,5 +25,6 @@ class CharmMysql(CharmBase):
     display_name = 'MySQL'
     deploy_priority = 0
     is_core = True
+    available_sources = ['charmstore']
 
 __charm_class__ = CharmMysql

--- a/cloudinstall/charms/neutron.py
+++ b/cloudinstall/charms/neutron.py
@@ -41,7 +41,7 @@ class CharmNeutron(CharmBase):
     allowed_assignment_types = [AssignmentType.BareMetal,
                                 AssignmentType.KVM]
     is_core = True
-    have_nextbranch = True
+    available_sources = ['charmstore', 'next']
 
     def post_proc(self):
         """ performs additional network configuration for charm """

--- a/cloudinstall/charms/neutron_api.py
+++ b/cloudinstall/charms/neutron_api.py
@@ -38,7 +38,7 @@ class CharmNeutronAPI(CharmBase):
                ('nova-cloud-controller:neutron-api',
                 'neutron-api:neutron-api')]
     is_core = True
-    have_nextbranch = True
+    available_sources = ['charmstore', 'next']
 
 
 __charm_class__ = CharmNeutronAPI

--- a/cloudinstall/charms/neutron_openvswitch.py
+++ b/cloudinstall/charms/neutron_openvswitch.py
@@ -28,6 +28,6 @@ class CharmNeutronOpenvswitch(CharmBase):
     subordinate = True
     openstack_release_min = 'j'
     is_core = True
-    have_nextbranch = True
+    available_sources = ['charmstore', 'next']
 
 __charm_class__ = CharmNeutronOpenvswitch

--- a/cloudinstall/charms/ntp.py
+++ b/cloudinstall/charms/ntp.py
@@ -30,5 +30,6 @@ class CharmNtp(CharmBase):
     subordinate = True
     deploy_priority = 0
     is_core = True
+    available_sources = ['charmstore']
 
 __charm_class__ = CharmNtp

--- a/cloudinstall/charms/rabbitmq.py
+++ b/cloudinstall/charms/rabbitmq.py
@@ -27,6 +27,6 @@ class CharmRabbitMQ(CharmBase):
     related = [('rabbitmq-server:amqp',
                 'neutron-openvswitch:amqp')]
     is_core = True
-    have_nextbranch = True
+    available_sources = ['charmstore', 'next']
 
 __charm_class__ = CharmRabbitMQ

--- a/cloudinstall/charms/swift.py
+++ b/cloudinstall/charms/swift.py
@@ -35,7 +35,7 @@ class CharmSwift(CharmBase):
     allow_multi_units = True
     conflicts = ['ceph-radosgw']
     depends = ['swift-proxy']
-    have_nextbranch = True
+    available_sources = ['charmstore', 'next']
 
     @classmethod
     def required_num_units(self):

--- a/cloudinstall/charms/swift_proxy.py
+++ b/cloudinstall/charms/swift_proxy.py
@@ -34,6 +34,6 @@ class CharmSwiftProxy(CharmBase):
     allow_multi_units = False
     depends = ['swift-storage']
     conflicts = ['ceph-radosgw']
-    have_nextbranch = True
+    available_sources = ['charmstore', 'next']
 
 __charm_class__ = CharmSwiftProxy

--- a/test/test_charms.py
+++ b/test/test_charms.py
@@ -66,10 +66,19 @@ class TestCharmBase(unittest.TestCase):
         self.mock_config.getopt.return_value = False
         self.charm.subordinate = True
         self.charm.charm_name = 'fake'
+        self.charm.available_sources = ['charmstore']
         self.charm.deploy('fake mspec')
         self.mock_jujuclient.deploy.assert_called_with('fake', 'fake',
                                                        0, ANY, None,
                                                        None)
+
+    def test_no_available_sources(self):
+        """ Exception raised when no available sources defined
+        """
+        self.mock_config.getopt.return_value = False
+        self.charm.charm_name = 'fake'
+        self.charm.available_sources = []
+        self.assertRaises(Exception, self.charm.deploy)
 
 
 class PrepCharmTest(unittest.TestCase):


### PR DESCRIPTION
We needed a way to define charms that are available in
some, all, any of particular branches in order to be made
available depending on the requirements.

For example, currently, the 'tempest' charm is only
available in a /next branch and not in the charmstore.

This feature allows us to be more specific as to what
remote sources are available for said charm.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/694)
<!-- Reviewable:end -->
