### PR TITLE
Use an observable for handling events

### DIFF
--- a/cloudinstall/controllers/installbase.py
+++ b/cloudinstall/controllers/installbase.py
@@ -110,7 +110,9 @@ class InstallController(Observer):
             self.ui.render_machine_wait_view(self.config)
             self.loop.redraw_screen()
 
-        self.alarm = self.loop.set_alarm_in(1, self.update)
+        alarm = self.loop.set_alarm_in(1, self.update)
+        self.observe('stop alarm', partial(self.loop.remove_alarm,
+                                           alarm))
 
     def do_install(self):
         """ Perform install
@@ -162,7 +164,5 @@ class InstallController(Observer):
             self.ui.select_install_type(
                 self.config.install_types(), self._set_install_type)
 
-        self.alarm = self.loop.set_alarm_in(1, self.update)
-        self.observe('stop alarm', partial(self.loop.remove_alarm,
-                                           self.alarm))
+        self.update()
         self.loop.run()

--- a/cloudinstall/ev.py
+++ b/cloudinstall/ev.py
@@ -125,7 +125,12 @@ class EventLoop:
 
     def set_alarm_in(self, interval, cb):
         if not self.config.getopt('headless'):
-            self.loop.set_alarm_in(interval, cb)
+            return self.loop.set_alarm_in(interval, cb)
+        return
+
+    def remove_alarm(self, handle):
+        if not self.config.getopt('headless'):
+            self.loop.remove_alarm(handle)
         return
 
     def run(self, cb=None):

--- a/cloudinstall/gui.py
+++ b/cloudinstall/gui.py
@@ -36,6 +36,7 @@ from cloudinstall.ui import (ScrollableWidgetWrap,
                              MaasServerInput,
                              LandscapeInput,
                              InfoDialog)
+from cloudinstall.notify import Event
 from cloudinstall.ui.utils import Color, Padding
 from cloudinstall.ui.helpscreen import HelpScreen
 from cloudinstall.machinewait import MachineWaitView
@@ -697,6 +698,7 @@ class PegasusGUI(WidgetWrap):
                "See {} for further info.".format(ex.args[0],
                                                  logpath))
         self.show_fatal_error_message(msg, handle_done)
+        Event('stop alarm')
 
     def select_install_type(self, install_types, cb):
         """ Dialog for selecting installation type

--- a/cloudinstall/notify.py
+++ b/cloudinstall/notify.py
@@ -33,12 +33,12 @@ class Observer:
 
 
 class Event:
-    def __init__(self, name, autofire=True):
+    def __init__(self, name, autoemit=True):
         self.name = name
-        if autofire:
-            self.fire()
+        if autoemit:
+            self.emit()
 
-    def fire(self):
+    def emit(self):
         for observer in Observer._observers:
             if self.name in observer._observables:
                 log.debug("Event called: {}".format(self.name))

--- a/cloudinstall/notify.py
+++ b/cloudinstall/notify.py
@@ -1,0 +1,45 @@
+# Copyright 2015 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+""" Simple observer class
+"""
+
+import logging
+
+log = logging.getLogger('cloudinstall.notify')
+
+
+class Observer:
+    _observers = []
+
+    def __init__(self):
+        self._observers.append(self)
+        self._observables = {}
+
+    def observe(self, event_name, cb):
+        self._observables[event_name] = cb
+
+
+class Event:
+    def __init__(self, name, autofire=True):
+        self.name = name
+        if autofire:
+            self.fire()
+
+    def fire(self):
+        for observer in Observer._observers:
+            if self.name in observer._observables:
+                log.debug("Event called: {}".format(self.name))
+                observer._observables[self.name]()


### PR DESCRIPTION
Currently, if an exception occurs we use a popup box
to let the user know that an error happened. However,
in some cases this may be hidden behind the fact that
the update alarms are still running. Meaning, it could
potentionally hide the overlay with another UI event
like updating the progress status view.

The problem this observer solves is it allows us to
call various functions based on the Event() emitted.

This code shows how that is possible when an exception
happens as it will remove the eventloops alarms and
allow the exception error message to stay seen in the
UI.

The other minor thing is the reason why I did this was
because I don't want to stop the eventloop entirely b/c
we'll still need access to keyboard commands, like (q)
in order for the user to quit out of the ui if a problem
occurs.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/697)
<!-- Reviewable:end -->
