### PR TITLE
Patch use errorview

### DIFF
--- a/bin/openstack-install
+++ b/bin/openstack-install
@@ -30,6 +30,7 @@ from cloudinstall.consoleui import ConsoleUI
 from cloudinstall.controllers.installbase import InstallController
 from cloudinstall.config import Config
 from cloudinstall.ev import EventLoop
+from cloudinstall.alarms import AlarmMonitor
 from cloudinstall import __version__ as version
 
 CFG_FILE = os.path.join(utils.install_home(),
@@ -238,6 +239,9 @@ if __name__ == '__main__':
 
     # Choose event loop
     ev = EventLoop(ui, cfg, logger)
+
+    # Bind event loops alarm tracking
+    AlarmMonitor.loop = ev
 
     try:
         install = InstallController(

--- a/bin/openstack-status
+++ b/bin/openstack-status
@@ -32,6 +32,7 @@ from cloudinstall.gui import PegasusGUI
 from cloudinstall.core import Controller
 from cloudinstall.consoleui import ConsoleUI
 from cloudinstall.ev import EventLoop
+from cloudinstall.alarms import AlarmMonitor
 from cloudinstall.api.container import Container
 from cloudinstall import utils
 from cloudinstall import log
@@ -122,6 +123,7 @@ if __name__ == '__main__':
         ui = PegasusGUI()
 
     ev = EventLoop(ui, config, logger)
+    AlarmMonitor.loop = ev
 
     core = Controller(ui=ui, config=config, loop=ev)
     # Create pidfile

--- a/cloudinstall/alarms.py
+++ b/cloudinstall/alarms.py
@@ -26,6 +26,6 @@ class AlarmMonitor:
         AlarmMonitor.alarms.append(handle)
 
     @classmethod
-    def abort(cls):
+    def remove_all(cls):
         for alarm in AlarmMonitor.alarms:
             AlarmMonitor.loop.remove_alarm(alarm)

--- a/cloudinstall/alarms.py
+++ b/cloudinstall/alarms.py
@@ -1,0 +1,31 @@
+# Copyright 2015 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+""" Alarm monitor
+"""
+
+
+class AlarmMonitor:
+    alarms = []
+    loop = None
+
+    @classmethod
+    def add_alarm(cls, handle):
+        AlarmMonitor.alarms.append(handle)
+
+    @classmethod
+    def abort(cls):
+        for alarm in AlarmMonitor.alarms:
+            AlarmMonitor.loop.remove_alarm(alarm)

--- a/cloudinstall/controllers/install/single.py
+++ b/cloudinstall/controllers/install/single.py
@@ -176,7 +176,6 @@ class SingleInstall:
         """
         self.tasker.start_task("Creating Container",
                                self.read_container_status)
-
         Container.create(self.container_name, self.userdata)
 
         with open(os.path.join(self.container_abspath, 'fstab'), 'w') as f:

--- a/cloudinstall/controllers/installbase.py
+++ b/cloudinstall/controllers/installbase.py
@@ -20,9 +20,7 @@ from cloudinstall.config import (INSTALL_TYPE_SINGLE,
                                  INSTALL_TYPE_MULTI,
                                  INSTALL_TYPE_LANDSCAPE)
 from cloudinstall.state import InstallState
-from cloudinstall.notify import Observer
 from cloudinstall.alarms import AlarmMonitor
-from cloudinstall.task import Tasker
 import cloudinstall.utils as utils
 
 from cloudinstall.controllers.install import (SingleInstall,
@@ -38,7 +36,7 @@ OPENSTACK_RELEASE_LABELS = dict(icehouse="Icehouse (2014.1.3)",
                                 liberty="Liberty (2015.2.0)")
 
 
-class InstallController(Observer):
+class InstallController:
 
     """ Install controller """
 
@@ -57,8 +55,6 @@ class InstallController(Observer):
             rel = self.config.getopt('openstack_release')
             label = OPENSTACK_RELEASE_LABELS[rel]
             self.ui.set_openstack_rel(label)
-        Observer.__init__(self)
-        Tasker.loop = loop
 
     def _set_install_type(self, install_type):
         self.install_type = install_type
@@ -113,7 +109,6 @@ class InstallController(Observer):
             self.loop.redraw_screen()
 
         AlarmMonitor.add_alarm(self.loop.set_alarm_in(1, self.update))
-        self.observe('stop alarm', AlarmMonitor.abort)
 
     def do_install(self):
         """ Perform install

--- a/cloudinstall/controllers/installbase.py
+++ b/cloudinstall/controllers/installbase.py
@@ -15,13 +15,14 @@
 
 import logging
 import os
-from functools import partial
 
 from cloudinstall.config import (INSTALL_TYPE_SINGLE,
                                  INSTALL_TYPE_MULTI,
                                  INSTALL_TYPE_LANDSCAPE)
 from cloudinstall.state import InstallState
 from cloudinstall.notify import Observer
+from cloudinstall.alarms import AlarmMonitor
+from cloudinstall.task import Tasker
 import cloudinstall.utils as utils
 
 from cloudinstall.controllers.install import (SingleInstall,
@@ -57,6 +58,7 @@ class InstallController(Observer):
             label = OPENSTACK_RELEASE_LABELS[rel]
             self.ui.set_openstack_rel(label)
         Observer.__init__(self)
+        Tasker.loop = loop
 
     def _set_install_type(self, install_type):
         self.install_type = install_type
@@ -110,9 +112,8 @@ class InstallController(Observer):
             self.ui.render_machine_wait_view(self.config)
             self.loop.redraw_screen()
 
-        alarm = self.loop.set_alarm_in(1, self.update)
-        self.observe('stop alarm', partial(self.loop.remove_alarm,
-                                           alarm))
+        AlarmMonitor.add_alarm(self.loop.set_alarm_in(1, self.update))
+        self.observe('stop alarm', AlarmMonitor.abort)
 
     def do_install(self):
         """ Perform install

--- a/cloudinstall/ev.py
+++ b/cloudinstall/ev.py
@@ -130,8 +130,9 @@ class EventLoop:
 
     def remove_alarm(self, handle):
         if not self.config.getopt('headless'):
-            self.loop.remove_alarm(handle)
-        return
+            log.debug("Removing alarm: {}".format(handle))
+            return self.loop.remove_alarm(handle)
+        return False
 
     def run(self, cb=None):
         """ Run eventloop

--- a/cloudinstall/gui.py
+++ b/cloudinstall/gui.py
@@ -37,6 +37,7 @@ from cloudinstall.ui import (ScrollableWidgetWrap,
                              LandscapeInput,
                              InfoDialog)
 from cloudinstall.notify import Event
+from cloudinstall.ui.views import ErrorView
 from cloudinstall.ui.utils import Color, Padding
 from cloudinstall.ui.helpscreen import HelpScreen
 from cloudinstall.machinewait import MachineWaitView
@@ -689,15 +690,10 @@ class PegasusGUI(WidgetWrap):
         self.add_services_dialog.update()
         self.frame.body = Filler(self.add_services_dialog)
 
-    def show_exception_message(self, ex,
-                               logpath="~/.cloud-install/commands.log"):
-        def handle_done(*args, **kwargs):
-            raise urwid.ExitMainLoop()
-        self.hide_widget_on_top()
-        msg = ("A fatal error has occurred: {}\n"
-               "See {} for further info.".format(ex.args[0],
-                                                 logpath))
-        self.show_fatal_error_message(msg, handle_done)
+    def show_exception_message(self, ex):
+        msg = ("A fatal error has occurred: {}\n".format(ex.args[0]))
+        log.error(msg)
+        self.frame.body = ErrorView(ex.args[0])
         Event('stop alarm')
 
     def select_install_type(self, install_types, cb):

--- a/cloudinstall/gui.py
+++ b/cloudinstall/gui.py
@@ -36,7 +36,7 @@ from cloudinstall.ui import (ScrollableWidgetWrap,
                              MaasServerInput,
                              LandscapeInput,
                              InfoDialog)
-from cloudinstall.notify import Event
+from cloudinstall.alarms import AlarmMonitor
 from cloudinstall.ui.views import ErrorView
 from cloudinstall.ui.utils import Color, Padding
 from cloudinstall.ui.helpscreen import HelpScreen
@@ -694,7 +694,7 @@ class PegasusGUI(WidgetWrap):
         msg = ("A fatal error has occurred: {}\n".format(ex.args[0]))
         log.error(msg)
         self.frame.body = ErrorView(ex.args[0])
-        Event('stop alarm')
+        AlarmMonitor.remove_all()
 
     def select_install_type(self, install_types, cb):
         """ Dialog for selecting installation type

--- a/cloudinstall/notify.py
+++ b/cloudinstall/notify.py
@@ -41,5 +41,7 @@ class Event:
     def emit(self):
         for observer in Observer._observers:
             if self.name in observer._observables:
-                log.debug("Event called: {}".format(self.name))
-                observer._observables[self.name]()
+                log.debug("Event called: {}".format(
+                    observer._observables[self.name]))
+                ret = observer._observables[self.name]()
+                log.debug("Processed event: {}".format(ret))

--- a/cloudinstall/task.py
+++ b/cloudinstall/task.py
@@ -1,5 +1,4 @@
-#
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -20,6 +19,7 @@ import time
 import yaml
 
 from cloudinstall import utils
+from cloudinstall.alarms import AlarmMonitor
 from cloudinstall.config import Config
 
 log = logging.getLogger('cloudinstall.task')
@@ -148,6 +148,7 @@ class Tasker:
         self.display_controller.render_node_install_wait(m)
         f = self.update_progress
         self.alarm = self.loop.set_alarm_in(0.3, f)
+        AlarmMonitor.add_alarm(self.alarm)
 
 
 class TaskerConsole:

--- a/cloudinstall/ui/views/error.py
+++ b/cloudinstall/ui/views/error.py
@@ -18,7 +18,6 @@ log output, and where to file a bug.
 """
 
 import logging
-import traceback
 from urwid import (Pile, Text, Filler, WidgetWrap, Divider)
 from cloudinstall.ui.buttons import cancel_btn
 from cloudinstall.ui.utils import Color, Padding
@@ -34,8 +33,6 @@ class ErrorViewException(Exception):
 class ErrorView(WidgetWrap):
     def __init__(self, error):
         log.debug("showing error view for: {}".format(error))
-        # tb = traceback.format_exc()
-        # log.exception(tb)
         bug_url = ("https://github.com/Ubuntu-Solutions-Engineering"
                    "/openstack-installer/issues/new")
         body = [

--- a/cloudinstall/ui/views/error.py
+++ b/cloudinstall/ui/views/error.py
@@ -33,9 +33,9 @@ class ErrorViewException(Exception):
 
 class ErrorView(WidgetWrap):
     def __init__(self, error):
-        log.debug("showing error view for: {}".format(error[0]))
-        tb = traceback.format_exc()
-        log.exception(tb)
+        log.debug("showing error view for: {}".format(error))
+        # tb = traceback.format_exc()
+        # log.exception(tb)
         bug_url = ("https://github.com/Ubuntu-Solutions-Engineering"
                    "/openstack-installer/issues/new")
         body = [
@@ -45,7 +45,7 @@ class ErrorView(WidgetWrap):
             Padding.center_95(
                 Divider("\N{BOX DRAWINGS LIGHT HORIZONTAL}", 1, 1)),
             Padding.center_85(Text("Reason:")),
-            Padding.center_80(Color.error_major(Text(str(error)))),
+            Padding.center_80(Color.error_major(Text(error))),
             Padding.line_break(""),
             Padding.center_85(
                 Text("Please file a bug with the above output and of "


### PR DESCRIPTION
Add support for a new ErrorView detailing where users should report bugs and provides a more readable design when exception happen.

Also added a alarm monitor to keep up with and easily abort all event loop alarms. I think this was one of the problems previously where some errors were being hidden due to the nature of the alarms and having them refresh the UI every so often.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/699)
<!-- Reviewable:end -->
