### PR TITLE
Don't initialize current_state if already set

### DIFF
--- a/cloudinstall/core.py
+++ b/cloudinstall/core.py
@@ -70,7 +70,9 @@ class Controller:
         self.juju_m_idmap = None  # for single, {instance_id: machine id}
         self.deployed_charm_classes = []
         self.placement_controller = None
-        self.config.setopt('current_state', ControllerState.INSTALL_WAIT.value)
+        if not self.config.getopt('current_state'):
+            self.config.setopt('current_state',
+                               ControllerState.INSTALL_WAIT.value)
 
     def update(self, *args, **kwargs):
         """Render UI according to current state and reset timer


### PR DESCRIPTION
Noticed an issue where we would set current_state to 0
regardless if it was already set in the config.

If the status screen exits then re-running the status
screen should automatically reload from current_state
2 which is the services view

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/703)
<!-- Reviewable:end -->
