### PR TITLE
Don't log an error which may be expected. 

### DIFF
--- a/cloudinstall/api/container.py
+++ b/cloudinstall/api/container.py
@@ -133,11 +133,6 @@ class Container:
         if subproc.returncode == 0:
             return decoded_output.strip()
         else:
-            log.debug("Error with command: "
-                      "[Output] '{}' [Error] '{}'".format(
-                          decoded_output.strip(),
-                          errors.strip()))
-
             raise ContainerRunException("Problem running {0} in container "
                                         "{1}:{2}".format(quoted_cmd, name, ip),
                                         subproc.returncode)


### PR DESCRIPTION
Let exception catchers handle it.

This will make the logs less confusing, since there are usually at least 10 lines with error logs that are really expected failures.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>