### PR TITLE
Status config error sanity

### DIFF
--- a/bin/openstack-status
+++ b/bin/openstack-status
@@ -112,10 +112,16 @@ if __name__ == '__main__':
     # Run openstack-status within container on single installs
     out = utils.get_command_output('hostname', user_sudo=True)
     hostname = out['output'].rstrip()
-    if config.is_single() and config.getopt('container_name') not in hostname:
-        logger.info("Running status within container")
-        Container.run_status(config.getopt('container_name'),
-                             'openstack-status', config)
+    if config.is_single():
+        container_name = config.getopt('container_name')
+        if container_name is False:
+            print("Error: Inconsistent config - single install "
+                  "without container_name set. Exiting.")
+            sys.exit(1)
+        if container_name not in hostname:
+            logger.info("Running status within container")
+            Container.run_status(config.getopt('container_name'),
+                                 'openstack-status', config)
 
     if config.getopt('headless'):
         ui = ConsoleUI()

--- a/bin/openstack-status
+++ b/bin/openstack-status
@@ -140,6 +140,7 @@ if __name__ == '__main__':
         atexit.register(partial(utils.cleanup, config))
         core.start()
     except Exception as e:
+        print("Error starting openstack-status: {}".format(e.args[0]))
         if opts.debug and not config.getopt('headless'):
             import pdb
             pdb.post_mortem()

--- a/cloudinstall/config.py
+++ b/cloudinstall/config.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import datetime
 import os
 import yaml
 import cloudinstall.utils as utils
@@ -55,9 +56,16 @@ class Config:
             self._config = cfg_obj
         self._cfg_file = cfg_file
 
-    def save(self):
+    def save(self, backup=True):
         """ Saves configuration """
         try:
+            if backup:
+                datestr = datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
+                backup_path = os.path.join(self.cfg_path, "config-backups")
+                backupfilename = "{}/config-{}.yaml".format(backup_path,
+                                                            datestr)
+                os.makedirs(backup_path, exist_ok=True)
+                os.rename(self.cfg_file, backupfilename)
             utils.spew(self.cfg_file,
                        yaml.safe_dump(dict(self._config),
                                       default_flow_style=False))

--- a/cloudinstall/config.py
+++ b/cloudinstall/config.py
@@ -43,7 +43,7 @@ class ConfigException(Exception):
 
 
 class Config:
-    def __init__(self, cfg_obj=None, cfg_file=None):
+    def __init__(self, cfg_obj=None, cfg_file=None, save_backups=True):
         if os.getenv("FAKE_API_DATA"):
             self._juju_env = {"bootstrap-config": {'name': "fake",
                                                    'maas-server': "FAKE"}}
@@ -55,11 +55,12 @@ class Config:
         else:
             self._config = cfg_obj
         self._cfg_file = cfg_file
+        self.save_backups = save_backups
 
-    def save(self, backup=True):
+    def save(self):
         """ Saves configuration """
         try:
-            if backup:
+            if self.save_backups:
                 datestr = datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
                 backup_path = os.path.join(self.cfg_path, "config-backups")
                 backupfilename = "{}/config-{}.yaml".format(backup_path,
@@ -97,7 +98,10 @@ class Config:
     @property
     def cfg_path(self):
         """ top level configuration path """
-        return os.path.join(utils.install_home(), '.cloud-install')
+        if self._cfg_file is None:
+            return os.path.join(utils.install_home(), '.cloud-install')
+        else:
+            return os.path.dirname(self._cfg_file)
 
     @property
     def cfg_file(self):

--- a/cloudinstall/core.py
+++ b/cloudinstall/core.py
@@ -660,5 +660,6 @@ class Controller:
             self.loop.register_callback('refresh_display', self.update)
             AlarmMonitor.add_alarm(self.loop.set_alarm_in(0, self.update),
                                    "controller-start")
+            cfg.setopt("gui_started", True)
             self.loop.run()
             self.loop.close()

--- a/cloudinstall/core.py
+++ b/cloudinstall/core.py
@@ -165,8 +165,12 @@ class Controller:
             self.maas_state, self.config)
 
         if path.exists(self.config.placements_filename):
-            with open(self.config.placements_filename, 'r') as pf:
-                self.placement_controller.load(pf)
+            try:
+                with open(self.config.placements_filename, 'r') as pf:
+                    self.placement_controller.load(pf)
+            except Exception as e:
+                log.exception("Exception loading placement")
+                raise Exception("Could not load placements.yaml")
             self.ui.status_info_message("Loaded placements from file")
             log.info("Loaded placements from "
                      "'{}'".format(self.config.placements_filename))

--- a/cloudinstall/core.py
+++ b/cloudinstall/core.py
@@ -168,9 +168,10 @@ class Controller:
             try:
                 with open(self.config.placements_filename, 'r') as pf:
                     self.placement_controller.load(pf)
-            except Exception as e:
+            except Exception:
                 log.exception("Exception loading placement")
-                raise Exception("Could not load placements.yaml")
+                raise Exception("Could not load "
+                                "{}.".format(self.config.placements_filename))
             self.ui.status_info_message("Loaded placements from file")
             log.info("Loaded placements from "
                      "'{}'".format(self.config.placements_filename))
@@ -664,6 +665,6 @@ class Controller:
             self.loop.register_callback('refresh_display', self.update)
             AlarmMonitor.add_alarm(self.loop.set_alarm_in(0, self.update),
                                    "controller-start")
-            cfg.setopt("gui_started", True)
+            self.config.setopt("gui_started", True)
             self.loop.run()
             self.loop.close()

--- a/cloudinstall/utils.py
+++ b/cloudinstall/utils.py
@@ -86,7 +86,7 @@ def cleanup(cfg):
     pid = os.path.join(install_home(), '.cloud-install/openstack.pid')
     if os.path.isfile(pid):
         os.remove(pid)
-    if not cfg.getopt('headless'):
+    if not cfg.getopt('headless') and cfg.getopt('gui_started'):
         log.debug('Attempting to reset the terminal')
         sys.stderr.write("\x1b[2J\x1b[H")
         call(['stty', 'sane'])

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -63,10 +63,11 @@ def parse_opts(argv):
 class TestGoodConfig(unittest.TestCase):
 
     def setUp(self):
-        self._temp_conf = Config(GOOD_CONFIG)
+        self._temp_conf = Config(GOOD_CONFIG, save_backups=False)
         with NamedTemporaryFile(mode='w+', encoding='utf-8') as tempf:
             # Override config file to save to
-            self.conf = Config(self._temp_conf._config, tempf.name)
+            self.conf = Config(self._temp_conf._config, tempf.name,
+                               save_backups=False)
 
     def test_save_openstack_password(self):
         """ Save openstack password to config """
@@ -181,10 +182,11 @@ class TestGoodConfig(unittest.TestCase):
 class TestBadConfig(unittest.TestCase):
 
     def setUp(self):
-        self._temp_conf = Config(BAD_CONFIG)
+        self._temp_conf = Config(BAD_CONFIG, save_backups=False)
         with NamedTemporaryFile(mode='w+', encoding='utf-8') as tempf:
             # Override config file to save to
-            self.conf = Config(self._temp_conf._config, tempf.name)
+            self.conf = Config(self._temp_conf._config, tempf.name,
+                               save_backups=False)
 
     def test_no_openstack_password(self):
         """ No openstack password defined """

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -33,7 +33,7 @@ class WaitForDeployedServicesReadyCoreTestCase(unittest.TestCase):
     """
 
     def setUp(self):
-        self.conf = Config({})
+        self.conf = Config({}, save_backups=False)
         self.mock_ui = MagicMock(name='ui')
         self.mock_log = MagicMock(name='log')
         self.mock_loop = MagicMock(name='loop')

--- a/test/test_ev.py
+++ b/test/test_ev.py
@@ -30,7 +30,7 @@ log = logging.getLogger('cloudinstall.test_ev')
 class EventLoopCoreTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.conf = Config({})
+        self.conf = Config({}, save_backups=False)
         self.mock_ui = MagicMock(name='ui')
         self.mock_log = MagicMock(name='log')
         self.mock_loop = MagicMock(name='loop')

--- a/test/test_juju_state.py
+++ b/test/test_juju_state.py
@@ -32,7 +32,7 @@ class JujuStateTestCase(unittest.TestCase):
     """
 
     def setUp(self):
-        self.conf = Config({})
+        self.conf = Config({}, save_backups=False)
         self.mock_ui = MagicMock(name='ui')
         self.mock_log = MagicMock(name='log')
         self.mock_loop = MagicMock(name='loop')

--- a/test/test_landscape_install.py
+++ b/test/test_landscape_install.py
@@ -38,7 +38,7 @@ class LandscapeInstallFinalTestCase(unittest.TestCase):
         self.loop = MagicMock()
         with NamedTemporaryFile(mode='w+', encoding='utf-8') as tempf:
             # Override config file to save to
-            self.conf = Config({}, tempf.name)
+            self.conf = Config({}, tempf.name, save_backups=False)
 
     def make_installer_with_config(self, landscape_creds=None,
                                    maas_creds=None):

--- a/test/test_multi_install.py
+++ b/test/test_multi_install.py
@@ -28,7 +28,7 @@ class MultiInstallTestCase(unittest.TestCase):
     def setUp(self):
         with NamedTemporaryFile(mode='w+', encoding='utf-8') as tempf:
             # Override config file to save to
-            self.conf = Config({}, tempf.name)
+            self.conf = Config({}, tempf.name, save_backups=False)
 
         dc = MagicMock(name="display_controller")
         loop = MagicMock(name="loop")

--- a/test/test_placement_controller.py
+++ b/test/test_placement_controller.py
@@ -51,7 +51,7 @@ class PlacementControllerTestCase(unittest.TestCase):
         self.mock_maas_state = MagicMock()
         with NamedTemporaryFile(mode='w+', encoding='utf-8') as tempf:
             utils.spew(tempf.name, yaml.dump(dict()))
-            self.conf = Config({}, tempf.name)
+            self.conf = Config({}, tempf.name, save_backups=False)
 
         self.pc = PlacementController(self.mock_maas_state,
                                       self.conf)
@@ -375,7 +375,7 @@ class PlacementControllerTestCase(unittest.TestCase):
     def test_load_machines_single(self):
         with NamedTemporaryFile(mode='w+', encoding='utf-8') as tempf:
             utils.spew(tempf.name, yaml.dump(dict()))
-            conf = Config({}, tempf.name)
+            conf = Config({}, tempf.name, save_backups=False)
 
         fake_assignments = {
             'fake_iid': {'constraints': {},
@@ -463,7 +463,7 @@ class PlacementControllerTestCase(unittest.TestCase):
         """gen_defaults should only use ready machines"""
         mock_maas_state = MagicMock()
         mock_maas_state.machines.return_value = []
-        c = Config()
+        c = Config(save_backups=False)
         pc = PlacementController(config=c, maas_state=mock_maas_state)
         # reset the mock to avoid looking at calls from
         # PlacementController.__init__().
@@ -486,7 +486,7 @@ class PlacementControllerTestCase(unittest.TestCase):
                     allcharms += charmclasses
             return cn in allcharms
 
-        c = Config()
+        c = Config(save_backups=False)
         pc = PlacementController(config=c)
 
         defaults = pc.gen_single()

--- a/test/test_placement_ui.py
+++ b/test/test_placement_ui.py
@@ -80,7 +80,7 @@ class ServiceWidgetTestCase(unittest.TestCase):
 
         with NamedTemporaryFile(mode='w+', encoding='utf-8') as tempf:
             utils.spew(tempf.name, yaml.dump(dict()))
-            self.conf = Config({}, tempf.name)
+            self.conf = Config({}, tempf.name, save_backups=False)
 
         self.pc = PlacementController(self.mock_maas_state,
                                       self.conf)
@@ -175,7 +175,7 @@ class MachineWidgetTestCase(unittest.TestCase):
         self.mock_maas_state = MagicMock()
         with NamedTemporaryFile(mode='w+', encoding='utf-8') as tempf:
             utils.spew(tempf.name, yaml.dump(dict()))
-            self.conf = Config({}, tempf.name)
+            self.conf = Config({}, tempf.name, save_backups=False)
 
         self.pc = PlacementController(self.mock_maas_state,
                                       self.conf)
@@ -253,7 +253,7 @@ class MachinesListTestCase(unittest.TestCase):
         self.mock_maas_state = MagicMock()
         with NamedTemporaryFile(mode='w+', encoding='utf-8') as tempf:
             utils.spew(tempf.name, yaml.dump(dict()))
-            self.conf = Config({}, tempf.name)
+            self.conf = Config({}, tempf.name, save_backups=False)
 
         self.pc = PlacementController(self.mock_maas_state,
                                       self.conf)
@@ -326,7 +326,7 @@ class ServicesListTestCase(unittest.TestCase):
         self.mock_maas_state = MagicMock()
         with NamedTemporaryFile(mode='w+', encoding='utf-8') as tempf:
             utils.spew(tempf.name, yaml.dump(dict()))
-            self.conf = Config({}, tempf.name)
+            self.conf = Config({}, tempf.name, save_backups=False)
 
         self.pc = PlacementController(self.mock_maas_state,
                                       self.conf)

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -30,7 +30,7 @@ class InstallStateTestCase(unittest.TestCase):
     def setUp(self):
         with NamedTemporaryFile(mode='w+', encoding='utf-8') as tempf:
             # Override config file to save to
-            self.conf = Config({}, tempf.name)
+            self.conf = Config({}, tempf.name, save_backups=False)
 
         self.bad_states_int = [5, 6, 7]
         self.good_states_int = [0, 1]
@@ -55,7 +55,7 @@ class ControllerStateTestCase(unittest.TestCase):
     def setUp(self):
         with NamedTemporaryFile(mode='w+', encoding='utf-8') as tempf:
             # Override config file to save to
-            self.conf = Config({}, tempf.name)
+            self.conf = Config({}, tempf.name, save_backups=False)
 
         self.bad_states_int = [5, 6, 7]
         self.good_states_int = [0, 1, 2]
@@ -84,7 +84,7 @@ class MultiInstallStateTestCase(unittest.TestCase):
     def setUp(self):
         with NamedTemporaryFile(mode='w+', encoding='utf-8') as tempf:
             # Override config file to save to
-            self.conf = Config({}, tempf.name)
+            self.conf = Config({}, tempf.name, save_backups=False)
         self.mock_ui = MagicMock(name='ui')
 
     @patch('cloudinstall.controllers.install.MultiInstall')
@@ -105,7 +105,7 @@ class CoreStateTestCase(unittest.TestCase):
     def setUp(self):
         with NamedTemporaryFile(mode='w+', encoding='utf-8') as tempf:
             # Override config file to save to
-            self.conf = Config({}, tempf.name)
+            self.conf = Config({}, tempf.name, save_backups=False)
         self.mock_ui = MagicMock(name='ui')
 
     @patch('cloudinstall.core.Controller')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -49,7 +49,7 @@ class TestRenderCharmConfig(unittest.TestCase):
     def setUp(self):
         with NamedTemporaryFile(mode='w+', encoding='utf-8') as tempf:
             # Override config file to save to
-            self.config = Config({}, tempf.name)
+            self.config = Config({}, tempf.name, save_backups=False)
 
         type(self.config).cfg_path = PropertyMock(return_value='fake_cfg_path')
         self.config.setopt('openstack_password', 'fake_pw')


### PR DESCRIPTION
Several commits that improve error handling behavior in openstack-status.

Fixes some long-standing annoyances.

Now if there's an error in config.yaml or placements.yaml, the exception message is printed to the screen and the terminal isn't reset because we haven't started the GUI yet.

Also prints a more understandable error message in some cases, in particular for the placements.yaml parsing.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/707)
<!-- Reviewable:end -->
