### PR TITLE
Move machinewaitview into ui.views path

### DIFF
--- a/cloudinstall/gui.py
+++ b/cloudinstall/gui.py
@@ -37,10 +37,10 @@ from cloudinstall.ui import (ScrollableWidgetWrap,
                              LandscapeInput,
                              InfoDialog)
 from cloudinstall.alarms import AlarmMonitor
-from cloudinstall.ui.views import ErrorView
+from cloudinstall.ui.views import (ErrorView,
+                                   MachineWaitView)
 from cloudinstall.ui.utils import Color, Padding
 from cloudinstall.ui.helpscreen import HelpScreen
-from cloudinstall.machinewait import MachineWaitView
 from cloudinstall.placement.ui import PlacementView
 from cloudinstall.placement.ui.add_services_dialog import AddServicesDialog
 

--- a/cloudinstall/ui/views/__init__.py
+++ b/cloudinstall/ui/views/__init__.py
@@ -14,3 +14,4 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from .error import ErrorView  # NOQA
+from .machinewait import MachineWaitView  # noqa

--- a/cloudinstall/ui/views/machinewait.py
+++ b/cloudinstall/ui/views/machinewait.py
@@ -1,5 +1,4 @@
-#
-# Copyright 2014 Canonical, Ltd.
+# Copyright 2014, 2015 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -23,7 +22,7 @@ from urwid import (AttrMap, Button, Divider, Filler, Padding, Pile,
 from cloudinstall.maas import connect_to_maas, FakeMaasState, MaasMachineStatus
 from cloudinstall import utils
 
-log = logging.getLogger('cloudinstall.install')
+log = logging.getLogger('cloudinstall.machinewait')
 
 
 class MachineWaitView(WidgetWrap):


### PR DESCRIPTION
Small organizational change to start moving Views into
their own ui.views namespace

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/758)
<!-- Reviewable:end -->
