### PR TITLE
Use neutron security group cli

### DIFF
--- a/share/templates/nova-controller-setup.sh
+++ b/share/templates/nova-controller-setup.sh
@@ -45,8 +45,9 @@ if [[ "$2" == "Single" ]]; then
 fi
 
 # configure security groups
-nova secgroup-add-rule default icmp -1 -1 0.0.0.0/0 || true
-nova secgroup-add-rule default tcp 22 22 0.0.0.0/0 || true
+neutron security-group-rule-create --direction ingress --ethertype IPv4 --protocol icmp --remote-ip-prefix 0.0.0.0/0 default || true
+neutron security-group-rule-create --direction ingress --ethertype IPv4 --protocol tcp --port-range-min 22 --port-range-max 22 --remote-ip-prefix 0.0.0.0/0 default || true
+
 
 # import key pair
 nova keypair-show ubuntu-keypair || nova keypair-add --pub-key /tmp/id_rsa.pub ubuntu-keypair


### PR DESCRIPTION
Advice from Rob to switch from nova to using neutron for
security group creation

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/769)
<!-- Reviewable:end -->
