### PR TITLE
Tweak container label for bare-metal machines

### DIFF
--- a/cloudinstall/ui/views/services.py
+++ b/cloudinstall/ui/views/services.py
@@ -243,7 +243,7 @@ class ServicesView(WidgetWrap):
                 "cpu_cores": m.cpu_cores,
                 "mem": m.mem,
                 "storage": m.storage,
-                "container": 'x',
+                "container": '-',
                 "machine": 0}
 
     def _detect_errors(self, unit, charm_class):


### PR DESCRIPTION
use '-' instead of 'x'

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/772)
<!-- Reviewable:end -->
