### PR TITLE
services gui: Update phase status every refresh.

### DIFF
--- a/cloudinstall/core.py
+++ b/cloudinstall/core.py
@@ -134,7 +134,7 @@ class Controller:
                     self.nodes, self.juju_state,
                     self.maas_state, self.config)
             else:
-                self.ui.services_view.refresh_nodes(self.nodes)
+                self.ui.refresh_services_view(self.nodes, self.config)
 
     def authenticate_juju(self):
         if not len(self.config.juju_env['state-servers']) > 0:

--- a/cloudinstall/gui.py
+++ b/cloudinstall/gui.py
@@ -361,6 +361,13 @@ class PegasusGUI(WidgetWrap):
                                           config)
         self.frame.body = self.services_view
         self.header.set_show_add_units_hotkey(True)
+        self.update_phase_status(config)
+
+    def refresh_services_view(self, nodes, config):
+        self.services_view.refresh_nodes(nodes)
+        self.update_phase_status(config)
+
+    def update_phase_status(self, config):
         dc = config.getopt('deploy_complete')
         dcstr = "complete" if dc else "pending"
         rc = config.getopt('relations_complete')


### PR DESCRIPTION
Tested on an existing single install using tools/fast-run-single-status. worked for me.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/774)
<!-- Reviewable:end -->
