### PR TITLE
status: Use extended info from juju if available

### DIFF
--- a/cloudinstall/service.py
+++ b/cloudinstall/service.py
@@ -46,6 +46,18 @@ class Unit:
         return self.unit.get('AgentState', 'unknown')
 
     @property
+    def workload_state(self):
+        return self.unit.get('Workload', {}).get('Status', '')
+
+    @property
+    def extended_agent_state(self):
+        return self.unit.get('UnitAgent', {}).get('Status', '')
+
+    @property
+    def workload_info(self):
+        return self.unit.get('Workload', {}).get('Info', '')
+    
+    @property
     def machine_id(self):
         """ Associate machine for unit
 

--- a/cloudinstall/ui/views/services.py
+++ b/cloudinstall/ui/views/services.py
@@ -157,6 +157,17 @@ class ServicesView(WidgetWrap):
         unit_w.agent_state.set_text(unit.agent_state)
         unit_w.icon.set_text(self.status_icon_state(charm_class, unit))
 
+        extended_agent_state = unit.extended_agent_state
+        if len(extended_agent_state) > 0 and \
+           extended_agent_state != 'idle':
+            unit_w.display_name.set_text("{}: {} - {}".format(
+                charm_class.display_name,
+                extended_agent_state,
+                unit.workload_info))
+        else:
+            unit_w.display_name.set_text("{}".format(
+                charm_class.display_name))
+
         # Special additional status text for these services
         if 'glance-simplestreams-sync' in unit.unit_name:
             status_oneline = get_sync_status().replace("\n", " - ")


### PR DESCRIPTION
Shows AgentState and WorkloadInfo, which show as AGENT-STATE and MESSAGE
in juju status --format=tabular.

Does not use WorkloadState, which is not well supported in current
charms and mostly just says 'unknown'.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/778)
<!-- Reviewable:end -->
