### PR TITLE
Use string for missing juju machine id

### DIFF
--- a/cloudinstall/juju.py
+++ b/cloudinstall/juju.py
@@ -125,7 +125,7 @@ class JujuState:
         for m in self.machines():
             if m.machine_id == machine_id:
                 return m
-        return Machine(-1, {})
+        return Machine('-', {})
 
     def machines(self):
         """ Machines property


### PR DESCRIPTION
Fixes crash in display when machine can not be created for a unit, or is
not ready yet.

When a machine can't be found, the default machine id of -1 is returned,
which is eventually passed as-is to a Text() constructor, which fails.

Nothing other than display and comparisons uses this value, so it's ok
to use something arbitrary as long as it's not something juju would
actually assign to a machine.

Signed-off-by: Mike McCracken <mike.mccracken@canonical.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/779)
<!-- Reviewable:end -->
