### PR TITLE
Rework node install wait view to not redraw entire screen

### DIFF
--- a/cloudinstall/core.py
+++ b/cloudinstall/core.py
@@ -90,7 +90,11 @@ class Controller:
                                           self.commit_placement)
 
         elif current_state == ControllerState.INSTALL_WAIT:
-            self.ui.render_node_install_wait(message="Waiting...")
+            if self.ui.node_install_wait_view is None:
+                self.ui.render_node_install_wait(
+                    message="Installer is initializing nodes. Please wait.")
+            else:
+                self.ui.node_install_wait_view.redraw_kitt()
             interval = self.config.node_install_wait_interval
         elif current_state == ControllerState.ADD_SERVICES:
             def submit_deploy():

--- a/cloudinstall/task.py
+++ b/cloudinstall/task.py
@@ -86,7 +86,8 @@ class Tasker:
                      "tasks_started: {}".format(self.tasks,
                                                 self.tasks_started_debug))
 
-        self.tasks[self.current_task_index] = (expectedname, time.time(), None)
+        self.tasks[self.current_task_index] = (expectedname,
+                                               time.time(), None)
         self.stopped = False
         if self.alarm is None:
             self.update_progress()
@@ -134,19 +135,23 @@ class Tasker:
                                               ts='   -')))
             elif e is None:
                 e = time.time()
-                ts = "{:6.2f} sec elapsed".format(e - s)
+                ts = "{:6d} sec(s) elapsed".format(int(e) - int(s))
                 m.append("{n:>{mw}}: {ts:<22}"
                          "\n".format(n=n, mw=self.max_width, ts=ts))
                 if self.task_info_func:
                     m.append(('label',
                               "\n{}\n\n".format(self.task_info_func())))
             else:
-                ts = "{:6.2f} sec".format(e - s)
+                ts = "{:6d} sec".format(int(e) - int(s))
                 m.append(('label', "{n:>{mw}}: {ts:<22}"
                           "\n".format(n=n, mw=self.max_width,
                                       ts=ts)))
 
-        self.display_controller.render_node_install_wait(m)
+        if self.display_controller.node_install_wait_view is None:
+            self.display_controller.render_node_install_wait(m)
+        else:
+            self.display_controller.node_install_wait_view.message.set_text(m)
+            self.display_controller.node_install_wait_view.redraw_kitt()
         f = self.update_progress
         self.alarm = self.loop.set_alarm_in(0.3, f)
         AlarmMonitor.add_alarm(self.alarm, "tasker-update-progress")

--- a/cloudinstall/ui/views/__init__.py
+++ b/cloudinstall/ui/views/__init__.py
@@ -17,3 +17,4 @@ from .error import ErrorView  # NOQA
 from .services import ServicesView  # NOQA
 from .machinewait import MachineWaitView  # noqa
 from .help import HelpView  # noqa
+from .nodeinstallwait import NodeInstallWaitView  # noqa

--- a/cloudinstall/ui/views/nodeinstallwait.py
+++ b/cloudinstall/ui/views/nodeinstallwait.py
@@ -1,0 +1,61 @@
+# Copyright 2014, 2015 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import random
+from urwid import (WidgetWrap, Text, Filler, Pile, Columns)
+from cloudinstall.ui.utils import Padding
+
+
+class NodeInstallWaitView(WidgetWrap):
+
+    load_attributes = [('pending_icon', "\u2581"),
+                       ('pending_icon', "\u2582"),
+                       ('pending_icon', "\u2583"),
+                       ('pending_icon', "\u2584"),
+                       ('pending_icon', "\u2585"),
+                       ('pending_icon', "\u2586"),
+                       ('pending_icon', "\u2587"),
+                       ('pending_icon', "\u2588")]
+
+    def __init__(self,
+                 message="Installer is initializing nodes. Please wait."):
+        self.message = Text(message, align="center")
+        self.loading_boxes = [Text(x) for x in self.load_attributes]
+        super().__init__(self._build_node_waiting())
+
+    def redraw_kitt(self):
+        """ Redraws the KITT bar
+        """
+        random.shuffle(self.load_attributes)
+        for i in self.loading_boxes:
+            i.set_text(
+                self.load_attributes[random.randrange(
+                    len(self.load_attributes))])
+
+    def _build_node_waiting(self):
+        """ creates a loading screen if nodes do not exist yet """
+        text = [Padding.line_break(""),
+                self.message,
+                Padding.line_break("")]
+
+        _boxes = []
+        _boxes.append(('weight', 1, Text('')))
+        for i in self.loading_boxes:
+            _boxes.append(('pack', i))
+        _boxes.append(('weight', 1, Text('')))
+        _boxes = Columns(_boxes)
+
+        return Filler(Pile(text + [_boxes]),
+                      valign="middle")


### PR DESCRIPTION
Cleanup to only redraw the elapsed seconds and KITT bar during
alarm's. Also show whole seconds rather than a float.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/783)
<!-- Reviewable:end -->
