### PR TITLE
test_multiplier: Test expected value in both cases

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -92,9 +92,11 @@ class TestRenderCharmConfig(unittest.TestCase):
         d = yaml.load(generated_yaml)
         wmul = d['nova-cloud-controller'].get('worker-multiplier', None)
         self.assertEqual(wmul, expected)
-        if d['glance'] is not None:
+        if expected:
             wmul = d['glance'].get('worker-multiplier', None)
             self.assertEqual(wmul, expected)
+        else:
+            self.assertEqual(d['glance'], None)
         wmul = d['keystone'].get('worker-multiplier', None)
         self.assertEqual(wmul, expected)
 


### PR DESCRIPTION
if worker_multiplier is not defined, the glance dict should be None, so
let's test that explicitly

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/784)
<!-- Reviewable:end -->
