### PR TITLE
catch encoding problems earlier

### DIFF
--- a/bin/openstack-install
+++ b/bin/openstack-install
@@ -23,6 +23,7 @@ import sys
 import os
 import logging
 import uuid
+import urwid
 from functools import partial
 from cloudinstall.log import setup_logger
 import cloudinstall.utils as utils
@@ -168,7 +169,7 @@ if __name__ == '__main__':
             print("Uninstall cancelled.")
             sys.exit(1)
 
-    if sys.getdefaultencoding() != 'utf-8':
+    if sys.getdefaultencoding() != 'utf-8' or not urwid.supports_unicode():
         print("Ubuntu OpenStack Installer requires unicode support. "
               "Please enable this on the system running the installer.\n\n")
         print("Example:\n")
@@ -176,6 +177,8 @@ if __name__ == '__main__':
         print("  export LANG=en_US.UTF-8")
         print("  export LANGUAGE=en_US.UTF-8")
         sys.exit(1)
+    else:
+        urwid.set_encoding('utf-8')
 
     if opts.get_config:
         conf_bin = "/usr/bin/openstack-config"

--- a/cloudinstall/gui.py
+++ b/cloudinstall/gui.py
@@ -16,7 +16,6 @@
 """ UI interface to the OpenStack Installer """
 
 from __future__ import unicode_literals
-import sys
 import logging
 
 import urwid
@@ -198,29 +197,10 @@ class StepInfo(WidgetWrap):
         raise SystemExit("Installation cancelled.")
 
 
-def _check_encoding():
-    """Set the Urwid global byte encoding to utf-8.
-
-    Exit the application if, for some reasons, the change does not have effect.
-    """
-    urwid.set_encoding('utf-8')
-    if not urwid.supports_unicode():
-        # Note: the following message must only include ASCII characters.
-        msg = (
-            'Error: your terminal does not seem to support UTF-8 encoding.\n'
-            'Please check your locale settings.\n'
-            'On Ubuntu, running the following might fix the problem:\n'
-            '  sudo locale-gen en_US.UTF-8\n'
-            '  sudo dpkg-reconfigure locales'
-        )
-        sys.exit(msg.encode('ascii'))
-
-
 class PegasusGUI(WidgetWrap):
     key_conversion_map = {'tab': 'down', 'shift tab': 'up'}
 
     def __init__(self, header=None, body=None, footer=None):
-        _check_encoding()  # Make sure terminal supports utf8
         self.header = header if header else Header()
         self.body = body if body else Banner()
         self.footer = footer if footer else StatusBar('')


### PR DESCRIPTION
If urwid is unable to determine proper encoding we fail before
reaching the ui.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/790)
<!-- Reviewable:end -->
