### PR TITLE
Raise exception on failed deploy

### DIFF
--- a/cloudinstall/charms/__init__.py
+++ b/cloudinstall/charms/__init__.py
@@ -270,9 +270,10 @@ export OS_REGION_NAME=\"RegionOne\"
 
             self.juju.deploy(_charm_name_rev, self.charm_name, num_units,
                              config_yaml, self.constraints, machine_spec)
-        except MacumbaError:
-            log.exception("Error deploying")
-            return True
+        except MacumbaError as e:
+            log.exception("Error deploying: {}".format(e))
+            raise Exception(
+                "Error deploying: {} {}".format(self.charm_name, e))
 
         self.ui.status_info_message("Deployed {0}.".format(self.display_name))
         return False


### PR DESCRIPTION
If we fail to deploy a charm raise an exception as this should
never happen.

Fixes #791

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/792)
<!-- Reviewable:end -->
