### PR TITLE
Rework eventloop

### DIFF
--- a/bin/openstack-install
+++ b/bin/openstack-install
@@ -32,7 +32,6 @@ from cloudinstall.consoleui import ConsoleUI
 from cloudinstall.controllers.installbase import InstallController
 from cloudinstall.config import Config
 from cloudinstall.ev import EventLoop
-from cloudinstall.alarms import AlarmMonitor
 from cloudinstall import __version__ as version
 
 CFG_FILE = os.path.join(utils.install_home(),
@@ -244,9 +243,9 @@ if __name__ == '__main__':
         sys.exit(1)
 
     if cfg.getopt('headless'):
-        ui = ConsoleUI()
+        ui = ConsoleUI(cfg)
     else:
-        ui = PegasusGUI(header=InstallHeader())
+        ui = PegasusGUI(cfg, header=InstallHeader())
 
     # Set proxy
     if cfg.getopt('http_proxy'):
@@ -257,15 +256,10 @@ if __name__ == '__main__':
         os.environ['https_proxy'] = cfg.getopt('https_proxy')
 
     cfg.setopt('session_id', str(uuid.uuid4()))
-    # Choose event loop
-    ev = EventLoop(ui, cfg, logger)
-
-    # Bind event loops alarm tracking
-    AlarmMonitor.loop = ev
 
     try:
         install = InstallController(
-            ui=ui, config=cfg, loop=ev)
+            ui=ui, config=cfg)
     except:
         print("Unable to start install controller")
         sys.exit(1)
@@ -280,9 +274,8 @@ if __name__ == '__main__':
         import atexit
         atexit.register(partial(utils.cleanup, cfg))
         install.start()
-    except:
-        if opts.debug and not cfg.getopt('headless'):
-            import pdb
-            pdb.post_mortem()
+    except Exception as e:
+        print("Error with openstack-install: {}".format(e))
+        raise e
     finally:
-        sys.exit(ev.error_code)
+        sys.exit(EventLoop.error_code)

--- a/bin/openstack-status
+++ b/bin/openstack-status
@@ -23,16 +23,10 @@ import signal
 import sys
 from functools import partial
 
-# Handle imports where the path is not automatically updated during install.
-# This really only happens when a binary is not in the usual /usr/bin location
-lib_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, lib_dir)
-
 from cloudinstall.gui import PegasusGUI
 from cloudinstall.core import Controller
 from cloudinstall.consoleui import ConsoleUI
 from cloudinstall.ev import EventLoop
-from cloudinstall.alarms import AlarmMonitor
 from cloudinstall.api.container import Container
 from cloudinstall import utils
 from cloudinstall import log
@@ -124,14 +118,12 @@ if __name__ == '__main__':
                                  'openstack-status', config)
 
     if config.getopt('headless'):
-        ui = ConsoleUI()
+        ui = ConsoleUI(config)
     else:
-        ui = PegasusGUI()
+        ui = PegasusGUI(config)
 
-    ev = EventLoop(ui, config, logger)
-    AlarmMonitor.loop = ev
+    core = Controller(ui=ui, config=config)
 
-    core = Controller(ui=ui, config=config, loop=ev)
     # Create pidfile
     utils.spew(config.pidfile, str(os.getppid()), utils.install_user())
 
@@ -141,9 +133,6 @@ if __name__ == '__main__':
         core.start()
     except Exception as e:
         print("Error starting openstack-status: {}".format(e.args[0]))
-        if opts.debug and not config.getopt('headless'):
-            import pdb
-            pdb.post_mortem()
         raise e
     finally:
-        sys.exit(ev.error_code)
+        sys.exit(EventLoop.error_code)

--- a/cloudinstall/alarms.py
+++ b/cloudinstall/alarms.py
@@ -15,20 +15,20 @@
 
 """ Alarm monitor
 """
+from cloudinstall.ev import EventLoop
 
 
 class AlarmMonitor:
     alarms = {}
-    loop = None
 
     @classmethod
     def add_alarm(cls, handle, name):
         if name in cls.alarms:
-            cls.loop.remove_alarm(cls.alarms[name])
+            EventLoop.remove_alarm(cls.alarms[name])
         cls.alarms[name] = handle
 
     @classmethod
     def remove_all(cls):
         for alarm in cls.alarms.values():
-            cls.loop.remove_alarm(alarm)
+            EventLoop.remove_alarm(alarm)
         cls.alarms = {}

--- a/cloudinstall/charms/__init__.py
+++ b/cloudinstall/charms/__init__.py
@@ -377,7 +377,6 @@ class CharmQueue:
     def __init__(self, ui, config, juju_state=None, juju=None,
                  deployed_charms=None):
         self.charm_post_proc_q = Queue()
-        self.is_running = False
         self.ui = ui
         self.config = config
         self.juju = juju

--- a/cloudinstall/consoleui.py
+++ b/cloudinstall/consoleui.py
@@ -26,12 +26,13 @@ log = logging.getLogger('cloudinstall.consoleui')
 
 class ConsoleUI:
 
-    def __init__(self):
+    def __init__(self, config):
+        self.config = config
         self._missing_attrs = []
 
-    def tasker(self, loop, config):
+    def tasker(self, config):
         """ Return console tasker """
-        return TaskerConsole(self, loop, config)
+        return TaskerConsole(self, config)
 
     def status_info_message(self, msg):
         log.info(msg)

--- a/cloudinstall/controllers/install/landscape.py
+++ b/cloudinstall/controllers/install/landscape.py
@@ -24,10 +24,9 @@ log = logging.getLogger('cloudinstall.c.i.landscape')
 
 class LandscapeInstall:
 
-    def __init__(self, loop, display_controller, config):
+    def __init__(self, display_controller, config):
         self.config = config
         self.display_controller = display_controller
-        self.loop = loop
         self.config.setopt('install_type', 'OpenStack Autopilot')
 
         session_id = self.config.getopt('session_id')
@@ -41,11 +40,11 @@ class LandscapeInstall:
         """ Performs the landscape deployment with existing MAAS
         """
         if self.config.getopt('headless'):
-            MultiInstall(self.loop, self.display_controller,
+            MultiInstall(self.display_controller,
                          self.config, self.landscape_tasks).do_install()
         else:
             MultiInstallExistingMaas(
-                self.loop, self.display_controller,
+                self.display_controller,
                 self.config, post_tasks=self.landscape_tasks).run()
 
     def _save_lds_creds(self, creds):

--- a/cloudinstall/controllers/install/multi.py
+++ b/cloudinstall/controllers/install/multi.py
@@ -24,7 +24,7 @@ import yaml
 
 from subprocess import check_output
 from tempfile import TemporaryDirectory
-
+from cloudinstall.ev import EventLoop
 from cloudinstall.state import InstallState
 from cloudinstall.netutils import get_ip_set
 
@@ -36,12 +36,11 @@ log = logging.getLogger('cloudinstall.c.i.multi')
 
 class MultiInstall:
 
-    def __init__(self, loop, display_controller,
+    def __init__(self, display_controller,
                  config, post_tasks=None):
-        self.loop = loop
         self.config = config
         self.display_controller = display_controller
-        self.tasker = self.display_controller.tasker(loop, config)
+        self.tasker = self.display_controller.tasker(config)
         self.tempdir = TemporaryDirectory(suffix="cloud-install")
         if post_tasks:
             self.post_tasks = post_tasks
@@ -151,7 +150,7 @@ class MultiInstall:
         if self.config.getopt('install_only'):
             log.info("Done installing, stopping here per --install-only.")
             self.config.setopt('install_only', True)
-            self.loop.exit(0)
+            EventLoop.exit(0)
 
         # Return control back to landscape_install if need be
         if not self.config.is_landscape():
@@ -165,8 +164,7 @@ class MultiInstall:
             log.debug("Finished MAAS step, now deploying Landscape.")
             return LandscapeInstallFinal(self,
                                          self.display_controller,
-                                         self.config,
-                                         self.loop).run()
+                                         self.config).run()
 
     def drop_privileges(self):
         if os.geteuid() != 0:
@@ -271,9 +269,8 @@ class LandscapeInstallFinal:
                   "archive/bundle.yaml")
 
     def __init__(self, multi_installer, display_controller,
-                 config, loop):
+                 config):
         self.config = config
-        self.loop = loop
         self.config.save()
         self.multi_installer = multi_installer
         self.display_controller = display_controller

--- a/cloudinstall/controllers/install/single.py
+++ b/cloudinstall/controllers/install/single.py
@@ -24,6 +24,7 @@ import platform
 import shutil
 from subprocess import call, check_call, check_output, STDOUT
 from cloudinstall import async, utils, netutils
+from cloudinstall.ev import EventLoop
 from cloudinstall.api.container import (Container,
                                         NoContainerIPException,
                                         ContainerRunException)
@@ -38,11 +39,10 @@ class SingleInstallException(Exception):
 
 class SingleInstall:
 
-    def __init__(self, loop, display_controller, config):
+    def __init__(self, display_controller, config):
         self.display_controller = display_controller
         self.config = config
-        self.loop = loop
-        self.tasker = self.display_controller.tasker(loop, config)
+        self.tasker = self.display_controller.tasker(config)
         self.progress_output = ""
         username = utils.install_user()
         self.container_name = 'openstack-single-{}'.format(username)
@@ -470,7 +470,7 @@ class SingleInstall:
         if self.config.getopt('install_only'):
             log.info("Done installing, stopping here per --install-only.")
             self.config.setopt('install_only', True)
-            self.loop.exit(0)
+            EventLoop.exit(0)
 
         # Update jujus no-proxy setting if applicable
         if self.config.getopt('http_proxy') or \

--- a/cloudinstall/controllers/installbase.py
+++ b/cloudinstall/controllers/installbase.py
@@ -21,6 +21,7 @@ from cloudinstall.config import (INSTALL_TYPE_SINGLE,
                                  INSTALL_TYPE_LANDSCAPE)
 from cloudinstall.state import InstallState
 from cloudinstall.alarms import AlarmMonitor
+from cloudinstall.ev import EventLoop
 import cloudinstall.utils as utils
 from cloudinstall.config import OPENSTACK_RELEASE_LABELS
 from cloudinstall.controllers.install import (SingleInstall,
@@ -40,10 +41,9 @@ class InstallController:
     MultiInstallExistingMaas = MultiInstallExistingMaas
     LandscapeInstall = LandscapeInstall
 
-    def __init__(self, ui, config, loop):
+    def __init__(self, ui, config):
         self.ui = ui
         self.config = config
-        self.loop = loop
         self.install_type = None
         self.config.setopt('current_state', InstallState.RUNNING.value)
         if not self.config.getopt('headless'):
@@ -88,7 +88,7 @@ class InstallController:
                                                  api_key=maas_apikey))
             log.info("Performing a Multi Install with existing MAAS")
             return self.MultiInstallExistingMaas(
-                self.loop, self.ui, self.config).run()
+                self.ui, self.config).run()
         else:
             self.ui.status_error_message('Please enter the MAAS server\'s '
                                          'IP address and API key to proceed.')
@@ -101,9 +101,9 @@ class InstallController:
             pass
         elif self.config.getopt('current_state') == InstallState.NODE_WAIT:
             self.ui.render_machine_wait_view(self.config)
-            self.loop.redraw_screen()
+            EventLoop.redraw_screen()
 
-        AlarmMonitor.add_alarm(self.loop.set_alarm_in(1, self.update),
+        AlarmMonitor.add_alarm(EventLoop.set_alarm_in(1, self.update),
                                "installcontroller-update")
 
     def do_install(self):
@@ -115,7 +115,7 @@ class InstallController:
         if self.install_type == INSTALL_TYPE_SINGLE[0]:
             self.ui.status_info_message("Performing a Single Install")
             self.SingleInstall(
-                self.loop, self.ui, self.config).run()
+                self.ui, self.config).run()
         elif self.install_type == INSTALL_TYPE_MULTI[0]:
             # TODO: Clean this up a bit more I dont like relying on
             # opts.headless but in a few places
@@ -123,7 +123,7 @@ class InstallController:
                 self.ui.status_info_message(
                     "Performing a Multi install with existing MAAS")
                 self.MultiInstallExistingMaas(
-                    self.loop, self.ui, self.config).run()
+                    self.ui, self.config).run()
             else:
                 self.ui.show_maas_input(
                     "Enter MAAS IP and API Key",
@@ -131,30 +131,40 @@ class InstallController:
         elif self.install_type == INSTALL_TYPE_LANDSCAPE[0]:
             log.info("Performing a OpenStack Autopilot install")
             self.LandscapeInstall(
-                self.loop, self.ui, self.config).run()
+                self.ui, self.config).run()
         else:
             os.remove(os.path.join(self.config.cfg_path, 'installed'))
             raise ValueError("Unknown install type: {}".format(
                 self.install_type))
 
+    def unhandled_input(self, key):
+        if key in ['q', 'Q']:
+            log.debug("q emitted, shutting down.")
+            EventLoop.exit(0)
+
     def start(self):
         """ Start installer eventloop
         """
+
+        EventLoop.build_loop(self.ui, self.config,
+                             unhandled_input=self.unhandled_input)
+
         if self.config.getopt('headless'):
             self.install_type = self.config.getopt('install_type')
             if not self.install_type:
                 log.error('Fatal error: '
                           'Unable to read install type from configuration.')
-                self.loop.exit(1)
+                EventLoop.exit(1)
             try:
                 self.do_install()
             except:
                 log.exception("Fatal error")
-                self.loop.exit(1)
+                EventLoop.exit(1)
 
         else:
             self.ui.select_install_type(
                 self.config.install_types(), self._set_install_type)
 
         self.update()
-        self.loop.run()
+
+        EventLoop.run()

--- a/cloudinstall/ev.py
+++ b/cloudinstall/ev.py
@@ -15,7 +15,6 @@
 
 import urwid
 import sys
-from cloudinstall.state import ControllerState
 import asyncio
 from cloudinstall.ui.palette import STYLES
 
@@ -28,110 +27,68 @@ class EventLoop:
 
     """ Abstracts out event loop
     """
+    loop = None
+    config = None
+    error_code = 0
 
-    def __init__(self, ui, config, log):
-        self.ui = ui
-        self.config = config
-        self.log = log
-        self.error_code = 0
-        self._callback_map = {}
-
-        self.loop = None
-
-        if not self.config.getopt('headless'):
-            self.loop = self._build_loop()
-
-    def register_callback(self, key, val):
-        """ Registers some additional callbacks that didn't make sense
-        to be added as part of its initial creation
-
-        TODO: Doubt this is the best way as its more of a band-aid
-        to core.py/add_charm and hotkeys in the gui.
-        """
-        self._callback_map[key] = val
-
-    def _build_loop(self):
+    @classmethod
+    def build_loop(cls, ui, config, **kwargs):
         """ Returns event loop configured with color palette """
-        additional_opts = {
-            'screen': urwid.raw_display.Screen(),
-            'unhandled_input': self.header_hotkeys,
-            'handle_mouse': True
-        }
-        additional_opts['screen'].set_terminal_properties(colors=256)
-        additional_opts['screen'].reset_default_terminal_palette()
-        evl = asyncio.get_event_loop()
-        return urwid.MainLoop(
-            self.ui, STYLES,
-            event_loop=urwid.AsyncioEventLoop(loop=evl), **additional_opts)
+        cls.config = config
 
-    def header_hotkeys(self, key):
-        if not self.config.getopt('headless'):
-            if key in ['j', 'down']:
-                self.ui.focus_next()
-            if key in ['k', 'up']:
-                self.ui.focus_previous()
-            if key in ['h', 'H', '?']:
-                self.ui.show_help_info()
-            if key in ['a', 'A', 'f6']:
-                if self.config.getopt('current_state') != \
-                   ControllerState.SERVICES:
-                    return
-                self.config.setopt('current_state',
-                                   ControllerState.ADD_SERVICES.value)
-            if key in ['q', 'Q']:
-                self.exit(0)
-            if key in ['r', 'R', 'f5']:
-                self.ui.status_info_message("View was refreshed")
-                self._callback_map['refresh_display']()
-            if key in ['esc']:
-                log.debug("setting previous controller: {}".format(
-                    self.ui.controller))
-                self.ui.frame.body = self.ui.controller
+        if not cls.config.getopt('headless'):
+            additional_opts = {
+                'screen': urwid.raw_display.Screen(),
+                'handle_mouse': True
+            }
+            additional_opts['screen'].set_terminal_properties(colors=256)
+            additional_opts['screen'].reset_default_terminal_palette()
+            additional_opts.update(**kwargs)
+            evl = asyncio.get_event_loop()
+            cls.loop = urwid.MainLoop(
+                ui, STYLES,
+                event_loop=urwid.AsyncioEventLoop(loop=evl), **additional_opts)
 
-    def exit(self, err=0):
-        self.error_code = err
-        self.log.info("Stopping eventloop")
-        if self.config.getopt('headless'):
+    @classmethod
+    def exit(cls, err=0):
+        cls.error_code = err
+        log.info("Stopping eventloop")
+        if cls.config.getopt('headless'):
             sys.exit(err)
 
         raise urwid.ExitMainLoop()
 
-    def close(self):
-        pass
-
-    def redraw_screen(self):
-        if not self.config.getopt('headless'):
+    @classmethod
+    def redraw_screen(cls):
+        if not cls.config.getopt('headless'):
             try:
-                self.loop.draw_screen()
+                cls.loop.draw_screen()
             except AssertionError as e:
-                self.log.exception("exception failure in redraw_screen")
+                log.exception("exception failure in redraw_screen")
                 raise e
 
-    def set_alarm_in(self, interval, cb):
-        if not self.config.getopt('headless'):
-            return self.loop.set_alarm_in(interval, cb)
+    @classmethod
+    def set_alarm_in(cls, interval, cb):
+        if not cls.config.getopt('headless'):
+            return cls.loop.set_alarm_in(interval, cb)
         return
 
-    def remove_alarm(self, handle):
-        if not self.config.getopt('headless'):
-            return self.loop.remove_alarm(handle)
+    @classmethod
+    def remove_alarm(cls, handle):
+        if not cls.config.getopt('headless'):
+            return cls.loop.remove_alarm(handle)
         return False
 
-    def run(self, cb=None):
+    @classmethod
+    def run(cls, cb=None):
         """ Run eventloop
 
         :param func cb: (optional) callback
         """
-        if not self.config.getopt('headless'):
+        if not cls.config.getopt('headless'):
             try:
-                self.loop.run()
+                cls.loop.run()
             except:
                 log.exception("Exception in ev.run():")
                 raise
         return
-
-    def __repr__(self):
-        if self.config.getopt('headless'):
-            return "<eventloop disabled>"
-        else:
-            return "<eventloop urwid based on asyncio>"

--- a/cloudinstall/placement/ui/__init__.py
+++ b/cloudinstall/placement/ui/__init__.py
@@ -332,10 +332,9 @@ class PlacementView(WidgetWrap):
     """
 
     def __init__(self, display_controller, placement_controller,
-                 loop, config, do_deploy_cb):
+                 config, do_deploy_cb):
         self.display_controller = display_controller
         self.placement_controller = placement_controller
-        self.loop = loop
         self.config = config
         self.do_deploy_cb = do_deploy_cb
         w = self.build_widgets()

--- a/cloudinstall/task.py
+++ b/cloudinstall/task.py
@@ -20,6 +20,7 @@ import yaml
 
 from cloudinstall import utils
 from cloudinstall import async
+from cloudinstall.ev import EventLoop
 from cloudinstall.alarms import AlarmMonitor
 from cloudinstall.config import Config
 
@@ -45,10 +46,9 @@ class Tasker:
 
     """
 
-    def __init__(self, display_controller, loop, config):
+    def __init__(self, display_controller, config):
         self.config = config
         self.display_controller = display_controller
-        self.loop = loop
         self.tasks = []  # (name, starttime, endtime=None)
         self.tasks_started_debug = []
         self.current_task_index = 0
@@ -153,7 +153,7 @@ class Tasker:
             self.display_controller.node_install_wait_view.message.set_text(m)
             self.display_controller.node_install_wait_view.redraw_kitt()
         f = self.update_progress
-        self.alarm = self.loop.set_alarm_in(0.3, f)
+        self.alarm = EventLoop.set_alarm_in(0.3, f)
         AlarmMonitor.add_alarm(self.alarm, "tasker-update-progress")
 
 
@@ -161,8 +161,7 @@ class TaskerConsole:
 
     """ Console tasker """
 
-    def __init__(self, display_controller, loop, config):
-        self.loop = loop
+    def __init__(self, display_controller, config):
         self.config = config
         self.display_controller = display_controller
         self.tasks = []
@@ -181,10 +180,10 @@ class FakeInstall:
 
     """For testing only, use as a replacement for MultiInstall*"""
 
-    def __init__(self, loop, display_controller):
-        super().__init__(display_controller, loop)
+    def __init__(self, display_controller):
+        super().__init__(display_controller)
         self.config = Config()
-        self.tasker = Tasker(display_controller, loop)
+        self.tasker = Tasker(display_controller)
         self.display_controller = display_controller
 
     def run(self):

--- a/cloudinstall/ui/views/help.py
+++ b/cloudinstall/ui/views/help.py
@@ -24,52 +24,61 @@ class HelpView(WidgetWrap):
     def __init__(self):
         help_text = [
             Padding.line_break(""),
-            Text("OpenStack Installer - Help \u21C5 Scroll (ESC) Close",
+            Text("OpenStack Installer - Help \u21C5 Scroll "
+                 "(S) To go back to Status screen",
                  align="center"),
-            Divider('-', 1, 1),
+            Divider("\N{BOX DRAWINGS LIGHT HORIZONTAL}", 1, 1),
             Text("For full documentation, please refer to "
                  "https://help.ubuntu.com/lts/clouddocs/installer/"),
-            Color.header_title(Text("Overview")),
-            Divider('-'),
-            Text("""
-- Header
-
-The header shows a few common command keys for quick reference.
-
-- Main Table
-
-The main table has a row for each Juju service in the current environment,
-updated every ten seconds. Each row will contain a status icon indicator, agent
-state, ip address, machine type, and hardware specifications.
-
-There may also be an additional status field with information in the event of
-provisioning errors or additional status notifications.
-
-- Footer
-
-The footer displays a status message, and the URLs for the two web dashboards
-installed, one for OpenStack Horizon and the other for the Juju GUI.
-            """),
+            Padding.line_break(""),
+            Text("Bug reports can be filed at http://git.io/p7IF"),
+            Padding.line_break(""),
             Color.header_title(Text("Command Reference")),
-            Divider('-'),
+            Divider("\N{BOX DRAWINGS LIGHT HORIZONTAL}", 1, 1),
             Text("""
-- (R/F5) refreshes the displayed state immediately
+- Keyboard Shortcuts
 
-- (A/a/F6) brings up a dialog box for adding additional units. This is how to
+  'A'   Add additional services to your cloud
+  'S'   Shows the status view
+  'Q'   Quit the application
+  'R'   Refreshes current view
+  'H'   Shows this help
+            """),
+            Color.header_title(Text("Overview")),
+            Divider("\N{BOX DRAWINGS LIGHT HORIZONTAL}", 1, 1),
+            Text("""
+- Layout
+
+  - Header
+    The header shows a few common command keys for quick reference.
+
+  - Main Table
+    The main table has a row for each Juju service in the current environment,
+    updated every ten seconds. Each row will contain a status icon indicator,
+    agent state, ip address, machine type, and hardware specifications.
+
+    There may also be an additional status field with information in the event
+    of provisioning errors or additional status notifications.
+
+  - Footer
+    The footer displays a status message
+            """),
+            Color.header_title(Text("Actions")),
+            Divider("\N{BOX DRAWINGS LIGHT HORIZONTAL}", 1, 1),
+            Text("""
+
+- Adding Services
+  (A) brings up a dialog box for adding additional units. This is how to
   add compute units or a storage service. This dialog takes care of launching
   required dependencies, so for example, launching swift here will add a
   swift-proxy service and enough swift-storage nodes to meet the replica
   criterion (currently 3).
-
-- '(H/h/?)' displays this help screen.
-
-- 'q' quits.
             """),
             Color.header_title(Text("Troubleshooting")),
-            Divider('-'),
+            Divider("\N{BOX DRAWINGS LIGHT HORIZONTAL}", 1, 1),
             Text("""
-The juju commands used to deploy the services listed are logged in
-~/.cloud-install/commands.log
+The installation log can be found at:
+  ~/.cloud-install/commands.log
 
 Note: In a multi-install, MAAS may be unable to find machines that match the
 default constraints set for one of the services the installer deploys. This

--- a/cloudinstall/ui/widgets/passwordinput.py
+++ b/cloudinstall/ui/widgets/passwordinput.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
 from cloudinstall.ui import Dialog
 
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock, patch
 from cloudinstall.config import Config
 from cloudinstall.core import Controller
 from cloudinstall.juju import JujuState
+from cloudinstall.ev import EventLoop
 
 log = logging.getLogger('cloudinstall.test_core')
 
@@ -39,9 +40,9 @@ class WaitForDeployedServicesReadyCoreTestCase(unittest.TestCase):
         self.mock_loop = MagicMock(name='loop')
 
         self.conf.setopt('headless', False)
+        EventLoop.loop = self.mock_loop
         self.dc = Controller(
-            ui=self.mock_ui, config=self.conf,
-            loop=self.mock_loop)
+            ui=self.mock_ui, config=self.conf)
         self.dc.initialize = MagicMock()
         self.dc.juju_state = JujuState(juju=MagicMock())
         self.dc.juju_state.all_agents_started = MagicMock()

--- a/test/test_ev.py
+++ b/test/test_ev.py
@@ -18,7 +18,7 @@
 import logging
 import unittest
 import urwid
-from unittest.mock import MagicMock, ANY
+from unittest.mock import MagicMock, patch
 from cloudinstall.ev import EventLoop
 from cloudinstall.config import Config
 from cloudinstall.core import Controller
@@ -37,100 +37,55 @@ class EventLoopCoreTestCase(unittest.TestCase):
         self.mock_ui = MagicMock(name='ui')
         self.mock_log = MagicMock(name='log')
         self.mock_loop = MagicMock(name='loop')
+        EventLoop.config = self.conf
 
-    def make_ev(self, headless=False):
-        self.conf.setopt('headless', headless)
-        return EventLoop(self.mock_ui, self.conf,
-                         self.mock_log)
-
-    def test_validate_loop(self):
+    @patch('cloudinstall.ev.EventLoop.run')
+    def test_validate_loop(self, run):
         """ Validate eventloop runs """
         self.conf.setopt('headless', False)
         self.conf.setopt('openstack_release', 'kilo')
         dc = Controller(
-            ui=self.mock_ui, config=self.conf,
-            loop=self.mock_loop)
+            ui=self.mock_ui, config=self.conf)
         dc.initialize = MagicMock()
         dc.start()
-        self.mock_loop.run.assert_called_once_with()
+        run.assert_called_once_with()
 
-    def test_validate_redraw_screen_commit_placement(self):
+    @patch('cloudinstall.core.Controller.update_node_states')
+    def test_validate_redraw_screen_commit_placement(self, update_node_states):
         """ Validate redraw_screen on commit_placement """
         self.conf.setopt('headless', False)
         dc = Controller(
-            ui=self.mock_ui, config=self.conf,
-            loop=self.mock_loop)
+            ui=self.mock_ui, config=self.conf)
         dc.initialize = MagicMock()
         dc.commit_placement()
-        self.mock_loop.redraw_screen.assert_called_once_with()
+        update_node_states.assert_called_once_with()
 
-    def test_validate_redraw_screen_enqueue(self):
-        """ Validate redraw_screen on enqueue_deployed_charms """
+    @patch('cloudinstall.core.Controller.update_node_states')
+    def test_validate_redraw_screen_enqueue(self, update_node_states):
+        """ Validate update_node_states on enqueue_deployed_charms """
         self.conf.setopt('headless', False)
         dc = Controller(
-            ui=self.mock_ui, config=self.conf,
-            loop=self.mock_loop)
+            ui=self.mock_ui, config=self.conf)
         dc.initialize = MagicMock()
         dc.enqueue_deployed_charms()
-        self.mock_loop.redraw_screen.assert_called_once_with()
-
-    def test_validate_set_alarm_in(self):
-        """ Validate set_alarm_in called with eventloop """
-        dc = Controller(
-            ui=self.mock_ui, config=self.conf,
-            loop=self.mock_loop)
-        dc.initialize = MagicMock()
-        self.conf.node_install_wait_interval = 1
-        dc.update(self.conf.node_install_wait_interval, ANY)
-        self.mock_loop.set_alarm_in.assert_called_once_with(1, ANY)
+        update_node_states.assert_called_once_with()
 
     def test_validate_exit(self):
         """ Validate error code set with eventloop """
-        ev = self.make_ev()
         dc = Controller(
-            ui=self.mock_ui, config=self.conf,
-            loop=ev)
+            ui=self.mock_ui, config=self.conf)
         dc.initialize = MagicMock()
         with self.assertRaises(urwid.ExitMainLoop):
-            dc.loop.exit(1)
-        self.assertEqual(ev.error_code, 1)
-
-    def test_hotkey_exit(self):
-        ev = self.make_ev()
-        dc = Controller(
-            ui=self.mock_ui, config=self.conf,
-            loop=ev)
-        dc.initialize = MagicMock()
-        with self.assertRaises(urwid.ExitMainLoop):
-            dc.loop.header_hotkeys('q')
-        self.assertEqual(ev.error_code, 0)
-
-    def test_repr_ev(self):
-        """ Prints appropriate class string for eventloop """
-        ev = self.make_ev()
-        dc = Controller(
-            ui=self.mock_ui, config=self.conf,
-            loop=ev)
-        dc.initialize = MagicMock()
-        self.assertEqual(str(ev), '<eventloop urwid based on asyncio>')
-
-    def test_repr_no_ev(self):
-        """ Prints appropriate class string for no eventloop """
-        ev = self.make_ev(True)
-        dc = Controller(
-            ui=self.mock_ui, config=self.conf,
-            loop=ev)
-        dc.initialize = MagicMock()
-        self.assertEqual(str(ev), '<eventloop disabled>')
+            EventLoop.exit(1)
+        self.assertEqual(EventLoop.error_code, 1)
 
     def test_validate_exit_no_ev(self):
         """ Validate SystemExit with no eventloop """
-        ev = self.make_ev(True)
+        self.conf.setopt('headless', True)
         dc = Controller(
-            ui=self.mock_ui, config=self.conf,
-            loop=ev)
+            ui=self.mock_ui, config=self.conf)
         dc.initialize = MagicMock()
         with self.assertRaises(SystemExit) as cm:
-            dc.loop.exit(1)
+            EventLoop.exit(1)
         exc = cm.exception
-        self.assertEqual(ev.error_code, exc.code, "Found loop")
+        self.assertEqual(EventLoop.error_code, exc.code, "Found loop")

--- a/test/test_landscape_install.py
+++ b/test/test_landscape_install.py
@@ -35,7 +35,6 @@ class LandscapeInstallFinalTestCase(unittest.TestCase):
     def setUp(self):
         self.mock_multi_installer = MagicMock()
         self.mock_display_controller = MagicMock()
-        self.loop = MagicMock()
         with NamedTemporaryFile(mode='w+', encoding='utf-8') as tempf:
             # Override config file to save to
             self.conf = Config({}, tempf.name, save_backups=False)
@@ -59,8 +58,7 @@ class LandscapeInstallFinalTestCase(unittest.TestCase):
 
         lif = LandscapeInstallFinal(self.mock_multi_installer,
                                     self.mock_display_controller,
-                                    self.conf,
-                                    self.loop)
+                                    self.conf)
         self.installer = lif
 
     def test_run_configure_not_sudo_user(self, mock_utils):

--- a/test/test_multi_install.py
+++ b/test/test_multi_install.py
@@ -31,8 +31,7 @@ class MultiInstallTestCase(unittest.TestCase):
             self.conf = Config({}, tempf.name, save_backups=False)
 
         dc = MagicMock(name="display_controller")
-        loop = MagicMock(name="loop")
-        self.installer = MultiInstall(loop, dc, self.conf)
+        self.installer = MultiInstall(dc, self.conf)
 
     @patch('cloudinstall.utils.get_command_output')
     def test_add_bootstrap_to_no_proxy(self, mock_gco):


### PR DESCRIPTION
Access the eventloop at the class level. Since there's only a single
loop running make the class easily accessible from everywhere else.

In addition, clean up the keyboard shortcuts to not conflict and place
inside the UI's main widget. Also rebind the keys to function keys
freeing up any conflicts with using normal characters during input
editing.

Update tests to reflect the changes in the Eventloop and also clean
up the help screen to reflect the new keyboard shortcuts.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/794)
<!-- Reviewable:end -->
