### PR TITLE
Use lxd

### DIFF
--- a/bin/openstack-install
+++ b/bin/openstack-install
@@ -24,6 +24,8 @@ import os
 import logging
 import uuid
 from functools import partial
+from subprocess import check_output, CalledProcessError
+
 from cloudinstall.log import setup_logger
 import cloudinstall.utils as utils
 from cloudinstall.gui import PegasusGUI, InstallHeader
@@ -121,6 +123,11 @@ def parse_options(argv):
                         default=False,
                         help="Enable LXD support for Nova Compute. Requires"
                         "--series vivid to be set.")
+    parser.add_argument('--topcontainer-type', dest='topcontainer_type',
+                        choices=['lxc', 'lxd'], default='lxc',
+                        help="Which container backend to use to create the "
+                        "top-level container for single installs. Does not "
+                        "affect multi install or containers created by juju.")
     # TODO: currently only works for single installs. Use
     # SHOW_JUJU_LOGS=1 in the env to enable. See github issue #421
     # parser.add_argument('--show-logs', action='store_true',
@@ -189,6 +196,20 @@ if __name__ == '__main__':
     if opts.use_nclxd and opts.ubuntu_series[0] < 'v':
         print("You must pass --series vivid or higher in order to use nclxd.")
         sys.exit(1)
+
+    if opts.topcontainer_type == 'lxd':
+        try:
+            lxc_version = check_output("dpkg -s lxc | grep Version "
+                                       " | cut -f 2 -d \' \'",
+                                       shell=True).decode()
+        except CalledProcessError as e:
+            print("Error checking lxc library version: {}"
+                  "\n{}".format(e, e.output))
+            sys.exit(1)
+        if lxc_version < "1.1.0":
+            print("Use of LXD requires lxc version 1.1 or later. "
+                  "You have {}.".format(lxc_version))
+            sys.exit(1)
 
     try:
         setup_logger(headless=cfg.getopt('headless'))

--- a/bin/openstack-juju
+++ b/bin/openstack-juju
@@ -21,7 +21,7 @@ import os
 import argparse
 import cloudinstall.utils as utils
 from cloudinstall.config import Config
-from cloudinstall.api.container import Container
+from cloudinstall.api.container import (LXDContainer, LXCContainer)
 
 CFG_FILE = os.path.join(utils.install_home(),
                         '.cloud-install/config.yaml')
@@ -41,7 +41,13 @@ if __name__ == '__main__':
                           name, cfg.juju_home(True), args))
         cmd = ("su ubuntu -c 'JUJU_HOME=~/.cloud-install/juju "
                "juju {}'".format(args))
-        out = Container.run(name, cmd, use_sudo=True)
+
+        if cfg.getopt("topcontainer_type") == 'lxd':
+            cdriver = LXDContainer
+        else:
+            cdriver = LXCContainer
+
+        out = cdriver.run(name, cmd, use_sudo=True)
         print(out)
     else:
         cmd = ("{} juju {}".format(cfg.juju_home(True), args))

--- a/bin/openstack-status
+++ b/bin/openstack-status
@@ -33,7 +33,7 @@ from cloudinstall.core import Controller
 from cloudinstall.consoleui import ConsoleUI
 from cloudinstall.ev import EventLoop
 from cloudinstall.alarms import AlarmMonitor
-from cloudinstall.api.container import Container
+from cloudinstall.api.container import LXDContainer, LXCContainer
 from cloudinstall import utils
 from cloudinstall import log
 from cloudinstall.config import Config
@@ -120,8 +120,13 @@ if __name__ == '__main__':
             sys.exit(1)
         if container_name not in hostname:
             logger.info("Running status within container")
-            Container.run_status(config.getopt('container_name'),
-                                 'openstack-status', config)
+            if config.getopt("topcontainer_type") == 'lxd':
+                cdriver = LXDContainer
+            else:
+                cdriver = LXCContainer
+
+            cdriver.run_status(config.getopt('container_name'),
+                               'openstack-status', config)
 
     if config.getopt('headless'):
         ui = ConsoleUI()

--- a/bin/openstack-uninstall
+++ b/bin/openstack-uninstall
@@ -36,8 +36,8 @@ case $WHAT in
   Single)
     echo Single install path.
     echo "Destroying $CONTAINER_NAME"
-    CONTAINER_BACKEND=$(openstack-config topcontainer_backend)
-    if [ "$CONTAINER_BACKEND" = "lxc" ]; then
+    CONTAINER_TYPE=$(openstack-config topcontainer_type)
+    if [ "$CONTAINER_TYPE" = "lxc" ]; then
 	lxc-stop -n $CONTAINER_NAME || true
 	lxc-destroy -n $CONTAINER_NAME || true
     else

--- a/bin/openstack-uninstall
+++ b/bin/openstack-uninstall
@@ -36,8 +36,14 @@ case $WHAT in
   Single)
     echo Single install path.
     echo "Destroying $CONTAINER_NAME"
-    lxc-stop -n $CONTAINER_NAME || true
-    lxc-destroy -n $CONTAINER_NAME || true
+    CONTAINER_BACKEND=$(openstack-config topcontainer_backend)
+    if [ "$CONTAINER_BACKEND" = "lxc" ]; then
+	lxc-stop -n $CONTAINER_NAME || true
+	lxc-destroy -n $CONTAINER_NAME || true
+    else
+	lxc delete $CONTAINER_NAME || true
+    fi
+
     if [ -n "$CONTAINER_NETWORK" ]; then
         echo "Deleting $CONTAINER_NETWORK"
         ip route del $CONTAINER_NETWORK || true

--- a/bin/status-listener
+++ b/bin/status-listener
@@ -34,7 +34,7 @@ def get_info():
     juju_path = check_output('openstack-install -g juju_path',
                              shell=True)
     new_env = os.environ
-    new_env['JUJU_HOME'] = juju_path
+    new_env['JUJU_HOME'] = juju_path.decode()
     read_id_proc = Popen(['juju', 'run', '--unit',
                           'glance-simplestreams-sync/0',
                           'cat /etc/glance-simplestreams-sync/identity.yaml'],

--- a/cloudinstall/api/container.py
+++ b/cloudinstall/api/container.py
@@ -46,7 +46,8 @@ class LXCContainer:
     @classmethod
     def exists(cls, name):
         out = subprocess.call("sudo lxc-info -n {}".format(name),
-                              shell=True)
+                              shell=True,
+                              stderr=subprocess.DEVNULL)
         return out == 0
 
     @classmethod

--- a/cloudinstall/api/container.py
+++ b/cloudinstall/api/container.py
@@ -503,6 +503,7 @@ class LXDContainer:
                 raise Exception("Container config already has userdata")
 
             cfgyaml['config']['user.user-data'] = "".join(uf.readlines())
+            cfgyaml['config']['security.privileged'] = True
 
         with tempfile.NamedTemporaryFile(delete=False) as cfgtmp:
             cfgtmp.write(yaml.dump(cfgyaml).encode())

--- a/cloudinstall/api/container.py
+++ b/cloudinstall/api/container.py
@@ -492,12 +492,14 @@ class LXDContainer:
             raise Exception(m)
 
         out = utils.get_command_output('lxc init {} {}'.format(imgname,
-                                                               name))
+                                                               name),
+                                       user_sudo=True)
         if out['status'] > 0:
             raise Exception("Unable to create container: " +
                             out['output'])
 
-        out = utils.get_command_output('lxc config show ' + name)
+        out = utils.get_command_output('lxc config show ' + name,
+                                       user_sudo=True)
         if out['status'] > 0:
             raise Exception("Unable to get container config: " +
                             out['output'])
@@ -515,7 +517,7 @@ class LXDContainer:
             cfgtmp.flush()
             cmd = 'cat {} | lxc config edit {}'.format(cfgtmp.name, name)
             log.debug("cmd is '{}'".format(cmd))
-            out = utils.get_command_output(cmd)
+            out = utils.get_command_output(cmd, user_sudo=True)
             if out['status'] > 0:
                 raise Exception("Unable to set userdata config: " +
                                 out['output'] + "ERR" + out['err'])
@@ -532,7 +534,8 @@ class LXDContainer:
     def add_config_entries(cls, name, configlines):
         raw_lxc_config = "\n".join(configlines)
         out = utils.get_command_output('lxc config set {} raw.lxc '
-                                       '"{}"'.format(name, raw_lxc_config))
+                                       '"{}"'.format(name, raw_lxc_config),
+                                       user_sudo=True)
         if out['status'] > 0:
             raise Exception("couldn't set container config")
 
@@ -542,7 +545,8 @@ class LXDContainer:
 
         :param str name: name of container
         """
-        out = utils.get_command_output('lxc start ' + name)
+        out = utils.get_command_output('lxc start ' + name,
+                                       user_sudo=True)
 
         if out['status'] > 0:
             raise Exception("Unable to start container: "
@@ -556,7 +560,7 @@ class LXDContainer:
 
         :param str name: name of container
         """
-        out = utils.get_command_output('lxc stop ' + name)
+        out = utils.get_command_output('lxc stop ' + name, user_sudo=True)
 
         if out['status'] > 0:
             raise Exception("Unable to stop container: "
@@ -570,7 +574,7 @@ class LXDContainer:
 
         :param str name: name of container
         """
-        out = utils.get_command_output('lxc delete ' + name)
+        out = utils.get_command_output('lxc delete ' + name, user_sudo=True)
 
         if out['status'] > 0:
             raise Exception("Unable to delete container: "
@@ -589,7 +593,7 @@ class LXDContainer:
         """
         while True:
             cmd = 'lxc info {} | grep Status'.format(name)
-            out = utils.get_command_output(cmd)
+            out = utils.get_command_output(cmd, user_sudo=True)
             if out['status'] != 0:
                 raise Exception("Error getting container info {}".format(out))
             outstr = out['output'].strip()

--- a/cloudinstall/api/container.py
+++ b/cloudinstall/api/container.py
@@ -323,7 +323,8 @@ class LXDContainer:
 
     @classmethod
     def exists(cls, name):
-        out = subprocess.call("lxc info " + name, shell=True)
+        out = subprocess.call("lxc info " + name, shell=True,
+                              stderr=subprocess.DEVNULL)
         return out == 0
 
     @classmethod

--- a/cloudinstall/api/container.py
+++ b/cloudinstall/api/container.py
@@ -328,9 +328,13 @@ class LXDContainer:
 
     @classmethod
     def get_status(cls, name):
-        s = subprocess.check_output("lxc info {} | grep Status".format(name),
-                                    shell=True,
-                                    stderr=subprocess.STDOUT).decode('utf-8')
+        try:
+            s = subprocess.check_output("lxc info {} | grep Status".format(name),
+                                        shell=True,
+                                        stderr=subprocess.STDOUT).decode('utf-8')
+        except subprocess.CalledProcessError as e:
+            s = "Status: Unknown"
+
         return s
 
     @classmethod

--- a/cloudinstall/api/container.py
+++ b/cloudinstall/api/container.py
@@ -15,8 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import subprocess
-from subprocess import (check_output,
-                        CalledProcessError)
 import logging
 import shlex
 import pty
@@ -25,6 +23,9 @@ import codecs
 import errno
 from collections import deque
 from cloudinstall import utils
+import tempfile
+import time
+import yaml
 
 log = logging.getLogger("cloudinstall.api.container")
 
@@ -39,19 +40,35 @@ class ContainerRunException(Exception):
     "Running cmd in container failed"
 
 
-class Container:
+class LXCContainer:
+    container_root = '/var/lib/lxc'
+
+    @classmethod
+    def exists(cls, name):
+        out = subprocess.call("sudo lxc-info -n {}".format(name),
+                              shell=True)
+        return out == 0
+
+    @classmethod
+    def get_status(cls, name):
+        s = subprocess.check_output("lxc-info -n {} -s || true".format(name),
+                                    shell=True,
+                                    stderr=subprocess.STDOUT)
+        return s.decode('utf-8')
+
     @classmethod
     def ip(cls, name):
         try:
-            ips = check_output("sudo lxc-info -n {} -i -H".format(name),
-                               shell=True)
+            ips = subprocess.check_output("sudo lxc-info -n {}"
+                                          " -i -H".format(name),
+                                          shell=True)
             ips = ips.split()
             log.debug("lxc-info found: '{}'".format(ips))
             if len(ips) == 0:
                 raise NoContainerIPException()
             log.debug("using {} as the container ip".format(ips[0].decode()))
             return ips[0].decode()
-        except CalledProcessError:
+        except subprocess.CalledProcessError:
             log.exception("error calling lxc-info to get container IP")
             raise NoContainerIPException()
 
@@ -160,27 +177,27 @@ class Container:
         os.execlp(args.popleft(), *args)
 
     @classmethod
-    def cp(cls, name, filepath, dst):
+    def cp(cls, name, src, dst):
         """ copy file to container
 
         :param str name: name of container
-        :param str filepath: file to copy to container
-        :param str dst: destination of remote path
+        :param str src: file to copy to container
+        :param str dst: destination full path
         """
         ip = cls.ip(name)
         cmd = ("scp -r -q "
                "-o \"StrictHostKeyChecking=no\" "
                "-o \"UserKnownHostsFile=/dev/null\" "
                "-i {identity} "
-               "{filepath} "
+               "{src} "
                "ubuntu@{ip}:{dst} ".format(ip=ip, dst=dst,
                                            identity=utils.ssh_privkey(),
-                                           filepath=filepath))
+                                           src=src))
         ret = utils.get_command_output(cmd)
         if ret['status'] > 0:
             raise Exception("There was a problem copying ({0}) to the "
                             "container ({1}:{2}): {3}".format(
-                                filepath, name, ip, ret['output']))
+                                src, name, ip, ret['output']))
 
     @classmethod
     def create(cls, name, userdata):
@@ -204,6 +221,22 @@ class Container:
             raise Exception("Unable to create container: "
                             "{0}".format(out['output']))
         return out['status']
+
+    @classmethod
+    def add_bind_mounts(cls, name, mounts):
+        container_abspath = os.path.join(cls.container_root, name)
+        with open(os.path.join(container_abspath, 'fstab'), 'w') as fstab:
+            for src, dest, mount_type in mounts:
+                fstab.write("{} {} none bind,create={}\n".format(
+                    src, dest, mount_type))
+        return ["lxc.mount = {}/fstab".format(container_abspath)]
+
+    @classmethod
+    def add_config_entries(cls, name, configlines):
+        container_abspath = os.path.join(cls.container_root, name)
+        with open(os.path.join(container_abspath, 'config'), 'a') as f:
+            for line in configlines:
+                f.write(line + "\n")
 
     @classmethod
     def start(cls, name, lxc_logfile):
@@ -284,3 +317,276 @@ class Container:
         out = utils.get_command_output(
             'sudo lxc-wait -n {0} -s RUNNING'.format(name))
         return out['status']
+
+
+class LXDContainer:
+
+    @classmethod
+    def exists(cls, name):
+        out = subprocess.call("lxc info " + name, shell=True)
+        return out == 0
+
+    @classmethod
+    def get_status(cls, name):
+        s = subprocess.check_output("lxc info {} | grep Status".format(name),
+                                    shell=True,
+                                    stderr=subprocess.STDOUT).decode('utf-8')
+        return s
+
+    @classmethod
+    def ip(cls, name):
+        try:
+            ips = subprocess.check_output("lxc list {}".format(name),
+                                          shell=True).decode()
+            ips = ips.splitlines()
+            if len(ips) < 5:    # four lines of table drawing
+                log.debug("Container not shown in lxc list: {} ".format(ips))
+                raise NoContainerIPException()
+
+            ip = ips[3].split('|')[3].strip()
+            # that gives us a comma-sep list, take the first one:
+            ip = ip.split(',')[0]
+            log.debug("lxc ip found: '{}'".format(ip))
+            if len(ip) == 0:
+                raise NoContainerIPException()
+            log.debug("using {} as the container ip".format(ip))
+            return ip
+
+        except subprocess.CalledProcessError:
+            log.exception("error calling lxc list to get container IP")
+            raise NoContainerIPException()
+
+    @classmethod
+    def run(cls, name, cmd, use_ssh=False, output_cb=None):
+        """ run command in container
+
+        :param str name: name of container
+        :param str cmd: command to run
+        """
+
+        if use_ssh:
+            ip = cls.ip(name)
+            quoted_cmd = shlex.quote(cmd)
+            wrapped_cmd = ("sudo -H -u {3} TERM=xterm256-color ssh -t -q "
+                           "-l ubuntu -o \"StrictHostKeyChecking=no\" "
+                           "-o \"UserKnownHostsFile=/dev/null\" "
+                           "-o \"ControlMaster=auto\" "
+                           "-o \"ControlPersist=600\" "
+                           "-i {2} "
+                           "{0} {1}".format(ip, quoted_cmd,
+                                            utils.ssh_privkey(),
+                                            utils.install_user()))
+        else:
+            quoted_cmd = cmd
+            wrapped_cmd = ("lxc exec {container_name} -- "
+                           "{cmd}".format(container_name=name,
+                                          cmd=cmd))
+
+        log.debug("Final command to run:\n'{}'".format(wrapped_cmd))
+        stdoutmaster, stdoutslave = pty.openpty()
+        subproc = subprocess.Popen(wrapped_cmd, shell=True,
+                                   stdout=stdoutslave,
+                                   stderr=subprocess.PIPE)
+        os.close(stdoutslave)
+        decoder = codecs.getincrementaldecoder('utf-8')()
+
+        def last_ten_lines(s):
+            chunk = s[-1500:]
+            lines = chunk.splitlines(True)
+            return ''.join(lines[-10:]).replace('\r', '')
+
+        decoded_output = ""
+        try:
+            while subproc.poll() is None:
+                try:
+                    b = os.read(stdoutmaster, 512)
+                except OSError as e:
+                    if e.errno != errno.EIO:
+                        raise
+                    break
+                else:
+                    final = False
+                    if not b:
+                        final = True
+                    decoded_chars = decoder.decode(b, final)
+                    if decoded_chars is None:
+                        continue
+
+                    decoded_output += decoded_chars
+                    if output_cb:
+                        ls = last_ten_lines(decoded_output)
+
+                        output_cb(ls)
+                    if final:
+                        break
+        finally:
+            os.close(stdoutmaster)
+            if subproc.poll() is None:
+                subproc.kill()
+            subproc.wait()
+
+        errors = [l.decode('utf-8') for l in subproc.stderr.readlines()]
+        if output_cb:
+            output_cb(last_ten_lines(decoded_output))
+
+        errors = ''.join(errors)
+
+        if subproc.returncode == 0:
+            return decoded_output.strip()
+        else:
+            raise ContainerRunException("Problem running {0} in container "
+                                        "{1}".format(quoted_cmd, name),
+                                        subproc.returncode)
+
+    @classmethod
+    def run_status(cls, name, cmd, config):
+        """ Runs cloud-status in container
+        """
+        ip = cls.ip(name)
+        cmd = ("sudo -H -u {2} TERM=xterm256-color ssh -t -q "
+               "-l ubuntu -o \"StrictHostKeyChecking=no\" "
+               "-o \"UserKnownHostsFile=/dev/null\" "
+               "-o \"ControlMaster=auto\" "
+               "-o \"ControlPersist=600\" "
+               "-i {1} "
+               "{0} {3}".format(ip, utils.ssh_privkey(),
+                                utils.install_user(), cmd))
+        log.debug("Running command without waiting "
+                  "for response.: {}".format(cmd))
+        args = deque(shlex.split(cmd))
+        os.execlp(args.popleft(), *args)
+
+    @classmethod
+    def cp(cls, name, src, dst):
+        """ copy file to container
+
+        :param str name: name of container
+        :param str src: file to copy to container
+        :param str dst: destination full path
+        """
+
+        cmd = ("lxc file push {src} {name}/{dst} ".format(dst=dst,
+                                                          name=name,
+                                                          src=src))
+        ret = utils.get_command_output(cmd)
+        if ret['status'] > 0:
+            raise Exception("There was a problem copying ({0}) to the "
+                            "container ({1}): out:'{2}'\nerr:{3}"
+                            "\ncmd:{4}".format(src, name,
+                                               ret['output'],
+                                               ret['err'],
+                                               cmd))
+
+    @classmethod
+    def create(cls, name, userdata):
+        """ creates a container from an image with the alias 'ubuntu'
+        """
+        out = utils.get_command_output('lxc image list | grep ubuntu')
+        if len(out['output']) == 0:
+            raise Exception("No 'ubuntu' image found")
+
+        imgname = os.getenv("LXD_IMAGE_NAME", "ubuntu")
+        out = utils.get_command_output('lxc init {} {}'.format(imgname,
+                                                               name))
+        if out['status'] > 0:
+            raise Exception("Unable to create container: "
+                            + out['output'])
+
+        out = utils.get_command_output('lxc config show ' + name)
+        if out['status'] > 0:
+            raise Exception("Unable to get container config: "
+                            + out['output'])
+
+        cfgyaml = yaml.load(out['output'])
+        with open(userdata, 'r') as uf:
+            if 'user.user_data' in cfgyaml['config']:
+                raise Exception("Container config already has userdata")
+
+            cfgyaml['config']['user.user-data'] = "".join(uf.readlines())
+
+        with tempfile.NamedTemporaryFile(delete=False) as cfgtmp:
+            cfgtmp.write(yaml.dump(cfgyaml).encode())
+            cfgtmp.flush()
+            cmd = 'cat {} | lxc config edit {}'.format(cfgtmp.name, name)
+            log.debug("cmd is '{}'".format(cmd))
+            out = utils.get_command_output(cmd)
+            if out['status'] > 0:
+                raise Exception("Unable to set userdata config: "
+                                + out['output'] + "ERR" + out['err'])
+
+        return 0
+
+    @classmethod
+    def add_bind_mounts(cls, name, mounts):
+        return ["lxc.mount.entry = {} {} "
+                "none bind,create={}".format(src, dest, ty)
+                for src, dest, ty in mounts]
+
+    @classmethod
+    def add_config_entries(cls, name, configlines):
+        raw_lxc_config = "\n".join(configlines)
+        out = utils.get_command_output('lxc config set {} raw.lxc '
+                                       '"{}"'.format(name, raw_lxc_config))
+        if out['status'] > 0:
+            raise Exception("couldn't set container config")
+
+    @classmethod
+    def start(cls, name, lxc_logfile):
+        """ starts lxc container
+
+        :param str name: name of container
+        """
+        out = utils.get_command_output('lxc start ' + name)
+
+        if out['status'] > 0:
+            raise Exception("Unable to start container: "
+                            "out:{}\nerr{}".format(out['output'],
+                                                   out['err']))
+        return out['status']
+
+    @classmethod
+    def stop(cls, name):
+        """ stops lxc container
+
+        :param str name: name of container
+        """
+        out = utils.get_command_output('lxc stop ' + name)
+
+        if out['status'] > 0:
+            raise Exception("Unable to stop container: "
+                            "{}".format(out['output']))
+
+        return out['status']
+
+    @classmethod
+    def destroy(cls, name):
+        """ destroys lxc container
+
+        :param str name: name of container
+        """
+        out = utils.get_command_output('lxc delete ' + name)
+
+        if out['status'] > 0:
+            raise Exception("Unable to delete container: "
+                            "{0}".format(out['output']))
+
+        return out['status']
+
+    @classmethod
+    def wait_checked(cls, name, check_logfile, interval=20):
+        """waits for container to be in RUNNING state.
+
+        Ignores check_logfile.
+
+        returns when the container 'name' is in RUNNING state.
+        raises an exception if errors are detected.
+        """
+        while True:
+            cmd = 'lxc info {} | grep Status'.format(name)
+            out = utils.get_command_output(cmd)
+            if out['status'] != 0:
+                raise Exception("Error getting container info {}".format(out))
+            outstr = out['output'].strip()
+            if outstr == "Status: Running":
+                return
+            time.sleep(4)

--- a/cloudinstall/api/container.py
+++ b/cloudinstall/api/container.py
@@ -481,11 +481,16 @@ class LXDContainer:
     def create(cls, name, userdata):
         """ creates a container from an image with the alias 'ubuntu'
         """
-        out = utils.get_command_output('lxc image list | grep ubuntu')
-        if len(out['output']) == 0:
-            raise Exception("No 'ubuntu' image found")
 
         imgname = os.getenv("LXD_IMAGE_NAME", "ubuntu")
+        out = utils.get_command_output('lxc image list | '
+                                       'grep {}'.format(imgname),
+                                       user_sudo=True)
+        if len(out['output']) == 0:
+            m = ("LXD: No image named '{}' found. "
+                 "Please import an image or set an alias.".format(imgname))
+            raise Exception(m)
+
         out = utils.get_command_output('lxc init {} {}'.format(imgname,
                                                                name))
         if out['status'] > 0:

--- a/cloudinstall/api/container.py
+++ b/cloudinstall/api/container.py
@@ -489,13 +489,13 @@ class LXDContainer:
         out = utils.get_command_output('lxc init {} {}'.format(imgname,
                                                                name))
         if out['status'] > 0:
-            raise Exception("Unable to create container: "
-                            + out['output'])
+            raise Exception("Unable to create container: " +
+                            out['output'])
 
         out = utils.get_command_output('lxc config show ' + name)
         if out['status'] > 0:
-            raise Exception("Unable to get container config: "
-                            + out['output'])
+            raise Exception("Unable to get container config: " +
+                            out['output'])
 
         cfgyaml = yaml.load(out['output'])
         with open(userdata, 'r') as uf:
@@ -512,8 +512,8 @@ class LXDContainer:
             log.debug("cmd is '{}'".format(cmd))
             out = utils.get_command_output(cmd)
             if out['status'] > 0:
-                raise Exception("Unable to set userdata config: "
-                                + out['output'] + "ERR" + out['err'])
+                raise Exception("Unable to set userdata config: " +
+                                out['output'] + "ERR" + out['err'])
 
         return 0
 

--- a/cloudinstall/api/container.py
+++ b/cloudinstall/api/container.py
@@ -197,8 +197,8 @@ class LXCContainer:
         ret = utils.get_command_output(cmd)
         if ret['status'] > 0:
             raise Exception("There was a problem copying ({0}) to the "
-                            "container ({1}:{2}): {3}".format(
-                                src, name, ip, ret['output']))
+                            "container ({1}:{2}): {3}\n{4}\ncmd:{5}".format(
+                                src, name, ip, ret['output'], ret['err'], cmd))
 
     @classmethod
     def create(cls, name, userdata):

--- a/cloudinstall/api/container.py
+++ b/cloudinstall/api/container.py
@@ -23,6 +23,7 @@ import codecs
 import errno
 from collections import deque
 from cloudinstall import utils
+import stat
 import tempfile
 import time
 import yaml
@@ -521,8 +522,8 @@ class LXDContainer:
         with tempfile.NamedTemporaryFile(delete=False) as cfgtmp:
             cfgtmp.write(yaml.dump(cfgyaml).encode())
             cfgtmp.flush()
+            os.chmod(cfgtmp.name, stat.S_IROTH | stat.S_IRWXU)
             cmd = 'cat {} | lxc config edit {}'.format(cfgtmp.name, name)
-            log.debug("cmd is '{}'".format(cmd))
             out = utils.get_command_output(cmd, user_sudo=True)
             if out['status'] > 0:
                 raise Exception("Unable to set userdata config: " +

--- a/cloudinstall/api/container.py
+++ b/cloudinstall/api/container.py
@@ -332,10 +332,12 @@ class LXDContainer:
     @classmethod
     def get_status(cls, name):
         try:
-            s = subprocess.check_output("lxc info {} | grep Status".format(name),
+            s = subprocess.check_output("lxc info {} | "
+                                        "grep Status".format(name),
                                         shell=True,
-                                        stderr=subprocess.STDOUT).decode('utf-8')
-        except subprocess.CalledProcessError as e:
+                                        stderr=subprocess.STDOUT)
+            s = s.decode('utf-8')
+        except subprocess.CalledProcessError:
             s = "Status: Unknown"
 
         return s

--- a/cloudinstall/charms/controller.py
+++ b/cloudinstall/charms/controller.py
@@ -100,6 +100,9 @@ class CharmNovaCloudController(CharmBase):
         setup_template = utils.load_template("nova-controller-setup.sh")
         if self.config.is_single():
             lxc_network = self.config.getopt('lxc_network')
+            if lxc_network is None:
+                log.error("lxc_network config not found")
+                raise Exception("can't find lxc_network")
             N = lxc_network.split('.')[2]
         else:
             # N is used to define networks for single, so we simply

--- a/cloudinstall/controllers/install/single.py
+++ b/cloudinstall/controllers/install/single.py
@@ -161,7 +161,7 @@ class SingleInstall:
         ctype = self.config.getopt('topcontainer_type')
         if ctype == 'lxc':
             container_abspath = os.path.join(self.cdriver.container_root,
-                                            name)
+                                             name)
             lxc_net_filename = os.path.join(container_abspath,
                                             'rootfs/etc/default/lxc-net')
             utils.spew(lxc_net_filename, lxc_net)

--- a/cloudinstall/controllers/install/single.py
+++ b/cloudinstall/controllers/install/single.py
@@ -250,8 +250,8 @@ class SingleInstall:
         # for wily+ hosts and containers, restart the preexisting
         # lxc-net to pick up our config:
         if platform.linux_distribution()[2][0] >= 'w':
-            Container.run(self.container_name,
-                          "systemctl restart lxc-net")
+            self.cdriver.run(self.container_name,
+                             "systemctl restart lxc-net")
 
         lxc_network = self.write_lxc_net_config()
         self.add_static_route(lxc_network)
@@ -511,11 +511,11 @@ class SingleInstall:
 
         trace = os.getenv("TRACE_JUJU", None)
         if trace:
-            Container.run(self.container_name,
-                          "{} juju set-env "
-                          "logging-config=\"<root>=TRACE\"".format(
-                              self.config.juju_home(use_expansion=True)),
-                          use_ssh=True, output_cb=self.set_progress_output)
+            self.cdriver.run(self.container_name,
+                             "{} juju set-env "
+                             "logging-config=\"<root>=TRACE\"".format(
+                                 self.config.juju_home(use_expansion=True)),
+                             use_ssh=True, output_cb=self.set_progress_output)
 
         self.cdriver.run(self.container_name,
                          "{0} juju status".format(

--- a/cloudinstall/controllers/install/single.py
+++ b/cloudinstall/controllers/install/single.py
@@ -160,7 +160,9 @@ class SingleInstall:
         log.info("Writing lxc-net config for {}".format(name))
         ctype = self.config.getopt('topcontainer_type')
         if ctype == 'lxc':
-            lxc_net_filename = os.path.join(self.cdriver.container_root,
+            container_abspath = os.path.join(self.cdriver.container_root,
+                                            name)
+            lxc_net_filename = os.path.join(container_abspath,
                                             'rootfs/etc/default/lxc-net')
             utils.spew(lxc_net_filename, lxc_net)
         elif ctype == 'lxd':

--- a/cloudinstall/controllers/install/single.py
+++ b/cloudinstall/controllers/install/single.py
@@ -242,11 +242,8 @@ class SingleInstall:
             Container.run(self.container_name,
                           "systemctl restart lxc-net")
 
-        if self.config.getopt("topcontainer_type") == 'lxc':
-            lxc_network = self.write_lxc_net_config()
-            self.add_static_route(lxc_network)
-        else:
-            log.info("Ignoring static route for now, TODO")
+        lxc_network = self.write_lxc_net_config()
+        self.add_static_route(lxc_network)
 
         self.tasker.start_task("Installing Dependencies",
                                self.read_progress_output)

--- a/share/templates/userdata.yaml
+++ b/share/templates/userdata.yaml
@@ -28,7 +28,7 @@ write_files:
       mknod /dev/net/tun c 10 200
       exit 0
     path: /etc/rc.local
-  permissions: '0755'
+    permissions: '0755'
 {%- endif %}
 packages:
   - software-properties-common

--- a/share/templates/userdata.yaml
+++ b/share/templates/userdata.yaml
@@ -19,15 +19,17 @@
 
 #cloud-config
 
+{%- if topcontainer_type == "lxc" %}
 write_files:
   - content: |
-      #!/bin/sh
+      #!/bin/sh -x
       mkdir -p /dev/net || true
       mknod /dev/kvm c 10 232
       mknod /dev/net/tun c 10 200
       exit 0
     path: /etc/rc.local
-    permissions: '0755'
+  permissions: '0755'
+{%- endif %}
 packages:
   - software-properties-common
 {%- if next_charms %}
@@ -92,7 +94,9 @@ resize_rootfs: False
 
 # Make sure we load our modules on first creation
 runcmd:
+{%- if topcontainer_type == "lxc" %}
   - [ sh, /etc/rc.local ]
+{%- endif %}
   - echo "export PATH=$PATH:/usr/sbin" >> /home/ubuntu/.bashrc
 {%- if http_proxy %}
   - echo "export http_proxy={{ http_proxy }}" >> /home/ubuntu/.bashrc


### PR DESCRIPTION
Add a --topcontainer-type flag to use LXD for the top level container instead of lxc-tools.

_NOTE_: this assumes you have a lxd image named 'ubuntu' downloaded into lxd already.
It'll complain if you don't.
Ideally this image will also match the distro series of your host. Specifically, don't use this on trusty with a wily lxd image, or wily with a trusty lxd image.

If you don't have such an image, do `lxd-images import ubuntu --alias ubuntu`



<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/795)
<!-- Reviewable:end -->
