### PR TITLE
Fix hanging on quit

### DIFF
--- a/cloudinstall/async.py
+++ b/cloudinstall/async.py
@@ -20,11 +20,20 @@ work.
 
 import logging
 from concurrent.futures import ThreadPoolExecutor
+from threading import Event
+import time
+
 log = logging.getLogger("cloudinstall.async")
 
 
+class ThreadCancelledException(Exception):
+    """Exception meaning intentional cancellation"""
+
 AsyncPool = ThreadPoolExecutor(1)
 log.debug('AsyncPool={}'.format(AsyncPool))
+
+
+ShutdownEvent = Event()
 
 
 def submit(func, exc_callback):
@@ -32,5 +41,27 @@ def submit(func, exc_callback):
         e = cb_f.exception()
         if e:
             exc_callback(e)
+    if ShutdownEvent.is_set():
+        log.debug("ignoring async.submit due to impending shutdown.")
+        return
     f = AsyncPool.submit(func)
     f.add_done_callback(cb)
+
+
+def shutdown():
+    ShutdownEvent.set()
+    AsyncPool.shutdown(wait=False)
+
+
+def sleep_until(s):
+    """returns after 's' seconds.
+
+    If the ShutdownEvent is raised before the wait is over,
+    raises a ThreadCancelledException.
+
+    """
+    start = time.time()
+    while not ShutdownEvent.wait(timeout=.1):
+        if time.time() - start >= s:
+            return True
+    raise ThreadCancelledException("Thread cancelled while sleeping")

--- a/cloudinstall/charms/__init__.py
+++ b/cloudinstall/charms/__init__.py
@@ -28,6 +28,7 @@ import time
 import requests
 
 from macumba import MacumbaError, ServerError
+from cloudinstall import async
 from cloudinstall import utils
 from cloudinstall.placement.controller import AssignmentType
 
@@ -433,6 +434,7 @@ class CharmQueue:
         log.debug("Processing relations: {}".format(valid_relations))
         while len(valid_relations) != len(completed_relations):
             for relation_a, relation_b in valid_relations:
+                async.sleep_until(0)
                 try:
                     log.debug("Calling juju.add_relation({}, {})".format(
                         relation_a, relation_b))
@@ -466,6 +468,8 @@ class CharmQueue:
         for charm in self._charm_classes():
             self.charm_post_proc_q.put(charm)
 
+        async.sleep_until(0)
+
         log.debug("Starting charm post processing watcher.")
         while not self.charm_post_proc_q.empty():
             try:
@@ -478,5 +482,6 @@ class CharmQueue:
                 msg = "Exception in post-processing watcher, re-trying."
                 log.exception(msg)
                 self.ui.status_error_message(msg)
-            time.sleep(10)
+
+            async.sleep_until(10)
         self.config.setopt('postproc_complete', True)

--- a/cloudinstall/charms/__init__.py
+++ b/cloudinstall/charms/__init__.py
@@ -24,7 +24,6 @@ import yaml
 from queue import Queue
 import shutil
 import subprocess
-import time
 import requests
 
 from macumba import MacumbaError, ServerError

--- a/cloudinstall/core.py
+++ b/cloudinstall/core.py
@@ -258,7 +258,7 @@ class Controller:
                                             "start: {}".format(summary))
                 _previous_summary = summary
 
-            time.sleep(1)
+            async.sleep_until(1)
 
         if len(self.juju_state.machines()) == 0:
             raise Exception("Expected some juju machines started.")
@@ -272,6 +272,7 @@ class Controller:
                 self.configure_lxc_network(controller_machine)
 
                 for juju_machine_id in self.juju_m_idmap.values():
+                    async.sleep_until(0)
                     self.run_apt_go_fast(juju_machine_id)
 
             self.deploy_using_placement()
@@ -454,7 +455,7 @@ class Controller:
                 log.debug("deployed_charm_classes={}".format(
                     PrettyLog(self.deployed_charm_classes)))
 
-                time.sleep(5)
+                async.sleep_until(5)
             update_pending_display()
 
     def try_deploy(self, charm_class):
@@ -551,13 +552,13 @@ class Controller:
             not_ready = [(a, b) for a, b in self.juju_state.get_agent_states()
                          if b != 'started']
             if len(not_ready) == not_ready_len:
-                time.sleep(3)
+                async.sleep_until(3)
                 continue
 
             not_ready_len = len(not_ready)
             log.info("Checking availability of {} ".format(
                 ", ".join(["{}:{}".format(a, b) for a, b in not_ready])))
-            time.sleep(3)
+            async.sleep_until(3)
 
         self.config.setopt('deploy_complete', True)
         self.ui.status_info_message(

--- a/cloudinstall/ev.py
+++ b/cloudinstall/ev.py
@@ -15,6 +15,7 @@
 
 import urwid
 import sys
+from cloudinstall import async
 from cloudinstall.state import ControllerState
 import asyncio
 from cloudinstall.ui.palette import STYLES
@@ -93,7 +94,7 @@ class EventLoop:
         self.log.info("Stopping eventloop")
         if self.config.getopt('headless'):
             sys.exit(err)
-
+        async.shutdown()
         raise urwid.ExitMainLoop()
 
     def close(self):

--- a/cloudinstall/gui.py
+++ b/cloudinstall/gui.py
@@ -22,6 +22,7 @@ import urwid
 from urwid import (Text, Pile,
                    Filler, Frame, WidgetWrap)
 
+from cloudinstall import async
 from cloudinstall.task import Tasker
 from cloudinstall.ui.widgets import (SelectorWithDescriptionWidget,
                                      PasswordInput,
@@ -259,9 +260,13 @@ class PegasusGUI(WidgetWrap):
         self.frame.body = Filler(self.add_services_dialog)
 
     def show_exception_message(self, ex):
-        msg = ("A fatal error has occurred: {}\n".format(ex.args[0]))
-        log.error(msg)
-        self.frame.body = ErrorView(ex.args[0])
+        if isinstance(ex, async.ThreadCancelledException):
+            log.debug("Thread cancelled intentionally.")
+        else:
+            msg = ("A fatal error has occurred: {}\n".format(ex.args[0]))
+            log.error(msg)
+            self.frame.body = ErrorView(ex.args[0])
+
         AlarmMonitor.remove_all()
 
     def select_install_type(self, install_types, cb):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -49,12 +49,12 @@ class WaitForDeployedServicesReadyCoreTestCase(unittest.TestCase):
     def test_validate_services_ready(self):
         """ Verifies wait_for_deployed_services_ready
 
-        time.sleep should not be called here as all services
+        async.sleep_until should not be called here as all services
         are in a started state.
         """
         self.dc.juju_state.all_agents_started.return_value = True
 
-        with patch('cloudinstall.core.time.sleep') as mock_sleep:
+        with patch('cloudinstall.async.sleep_until') as mock_sleep:
             self.dc.wait_for_deployed_services_ready()
         self.assertEqual(len(mock_sleep.mock_calls), 0)
 
@@ -62,13 +62,13 @@ class WaitForDeployedServicesReadyCoreTestCase(unittest.TestCase):
         """ Verifies wait_for_deployed_services_ready against some of the
         services in started state
 
-        Here we test if time.sleep was called twice due to some services
+        Here we test if async.sleep_until was called twice due to some services
         being in an installing and allocating state.
         """
         self.dc.juju_state.all_agents_started.side_effect = [
             False, False, True, True]
 
-        with patch('cloudinstall.core.time.sleep') as mock_sleep:
+        with patch('cloudinstall.async.sleep_until') as mock_sleep:
             self.dc.wait_for_deployed_services_ready()
         print(mock_sleep.mock_calls)
         self.assertEqual(len(mock_sleep.mock_calls), 2)


### PR DESCRIPTION
Shutdown was hanging after the urwid loop stopped, due to threads in the
thread pool looping forever, or just for a long time.

Async launched threads need to occasionally check if they need to kill
themselves.

Added async.shutdown to cleanly shutdown the executor and signal an
event that the threads check occasionally.

Added async.sleep_until to provide a sleep() workalike that checks every
.1 seconds for the shutdown Event and raises an exception if it is set.
Occasionally this is used with a timeout of 0 to just check for the
event once.

These changes should quit cleanly within a minimum of time - although
sometimes it will still stall while waiting for e.g. a remote execution
of a post-processing script, as the checks are only inline.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/806)
<!-- Reviewable:end -->
