### PR TITLE
consoleui: add clear_status dummy

### DIFF
--- a/cloudinstall/consoleui.py
+++ b/cloudinstall/consoleui.py
@@ -36,6 +36,9 @@ class ConsoleUI:
     def status_info_message(self, msg):
         log.info(msg)
 
+    def clear_status(self):
+        pass
+
     def show_step_info(self, msg):
         log.info(msg)
 


### PR DESCRIPTION
Avoids spurious error message in landscape headless installs, that look like this:

```
[INFO: 01-14 23:46:34] Running
[INFO: 01-14 23:46:44] Downloading latest Landscape Autopilot bundle
[INFO: 01-14 23:46:44] Deploying Landscape
[INFO: 01-14 23:56:01] Registering against Landscape
...
[INFO: 01-14 23:56:04] Missing ConsoleUI() attribute: clear_status
etc ...
```

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/824)
<!-- Reviewable:end -->
