### PR TITLE
Add 'source' option to glance-simplestreams-sync

### DIFF
--- a/share/templates/charmconf.yaml
+++ b/share/templates/charmconf.yaml
@@ -120,6 +120,7 @@ glance:
 
 glance-simplestreams-sync:
   use_swift: False
+  source: ppa:cloud-installer/simplestreams-testing
 
 juju-gui:
   password: {{openstack_password}}


### PR DESCRIPTION
The cloud-installer/simplestreams-testing PPA has a copy of
simplestreams for trusty that includes the progress reporting code we
need. It had been installed unconditionally by the GSS charm but as that
charm is now in use by others, that has caused problems.

Instead we have added a 'source' config option in this MP:
https://code.launchpad.net/~mikemc/charms/trusty/glance-simplestreams-sync/add-source-config/+merge/282806
this allows us to just set it here and others will not use it by default.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/826)
<!-- Reviewable:end -->
