### PR TITLE
fix bug in autoplacement

### DIFF
--- a/cloudinstall/placement/controller.py
+++ b/cloudinstall/placement/controller.py
@@ -557,6 +557,7 @@ class PlacementController:
 
         self.update_and_save()
 
+        unassigned_services = list(self.unassigned_undeployed_services())
         unassigned_reqs = [c for c in unassigned_services if
                            self.get_charm_state(c)[0] == CharmState.REQUIRED]
 


### PR DESCRIPTION
refresh unassigned_services before checking if any services are
unassigned after performing auto assignment

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/827)
<!-- Reviewable:end -->
