### PR TITLE
fix no machines UI

### DIFF
--- a/cloudinstall/placement/ui/__init__.py
+++ b/cloudinstall/placement/ui/__init__.py
@@ -293,8 +293,8 @@ class MachinesColumn(WidgetWrap):
                                                 align='center',
                                                 width=BUTTON_SIZE)])
 
-        # 1 machine is the subordinate placeholder:
-        if len(self.placement_controller.machines()) == 1:
+        # 2 machines is the subordinate placeholder + juju default:
+        if len(self.placement_controller.machines()) == 2:
             self.main_pile.contents[2] = (self.empty_maas_widgets,
                                           self.main_pile.options())
         else:


### PR DESCRIPTION
'no machines' MAAS ui will not be shown, even when there really aren't
any, because we've added the juju default placeholder.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/831)
<!-- Reviewable:end -->
