### PR TITLE
LXD toplevel container: Add /dev/net/tun and /dev/kvm as devices

### DIFF
--- a/cloudinstall/api/container.py
+++ b/cloudinstall/api/container.py
@@ -553,6 +553,17 @@ class LXDContainer:
             raise Exception("couldn't set container config")
 
     @classmethod
+    def add_devices(cls, name, devices):
+        for dname, dtype, keyvalstr in devices:
+            cmd = 'lxc config device add {} {} {} {}'.format(name, dname,
+                                                             dtype, keyvalstr)
+            out = utils.get_command_output(cmd, user_sudo=True)
+            if out['status'] > 0:
+                raise Exception("couldn't add device:"
+                                "out:{}\nerr{}".format(out['output'],
+                                                       out['err']))
+
+    @classmethod
     def start(cls, name, lxc_logfile):
         """ starts lxc container
 

--- a/cloudinstall/controllers/install/single.py
+++ b/cloudinstall/controllers/install/single.py
@@ -205,8 +205,11 @@ class SingleInstall:
         if topcontainer_type == 'lxc':
             mounts += [("/var/cache/lxc", "var/cache/lxc", "dir")]
         elif topcontainer_type == 'lxd':
-            mounts += [("/dev/kvm", "dev/kvm", "file"),
-                       ("/dev/net", "dev/net", "dir")]
+            self.cdriver.add_devices(self.container_name,
+                                     [('tun', 'unix-char',
+                                       'path=/dev/net/tun'),
+                                      ('kvm', 'unix-char',
+                                       'path=/dev/kvm')])
         else:
             raise Exception("Uknown container type " + topcontainer_type)
 


### PR DESCRIPTION
Required because of recent changes to LXD that no longer include LXC's default device configuration.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/838)
<!-- Reviewable:end -->
