### PR TITLE
Bump all pinned charms to latest.

### DIFF
--- a/cloudinstall/charms/ceilometer.py
+++ b/cloudinstall/charms/ceilometer.py
@@ -25,7 +25,7 @@ class CharmCeilometer(CharmBase):
     """ Ceilometer directives """
 
     charm_name = 'ceilometer'
-    charm_rev = 15
+    charm_rev = 17
     display_name = 'Ceilometer'
     deploy_priority = 100
     contrib = True

--- a/cloudinstall/charms/ceilometer_agent.py
+++ b/cloudinstall/charms/ceilometer_agent.py
@@ -25,7 +25,7 @@ class CharmCeilometerAgent(CharmBase):
     """ Ceilometer-agent directives """
 
     charm_name = 'ceilometer-agent'
-    charm_rev = 11
+    charm_rev = 13
     display_name = 'Ceilometer-Agent'
     subordinate = True
     contrib = True

--- a/cloudinstall/charms/ceph.py
+++ b/cloudinstall/charms/ceph.py
@@ -25,7 +25,7 @@ class CharmCeph(CharmBase):
     """ Ceph directives """
 
     charm_name = 'ceph'
-    charm_rev = 42
+    charm_rev = 43
     display_name = 'Ceph'
     display_priority = DisplayPriorities.Storage
     related = [('ceph:client', 'cinder-ceph:ceph'),

--- a/cloudinstall/charms/ceph_radosgw.py
+++ b/cloudinstall/charms/ceph_radosgw.py
@@ -25,7 +25,7 @@ class CharmCephRadosGw(CharmBase):
     """ Ceph radosgw directives """
 
     charm_name = 'ceph-radosgw'
-    charm_rev = 18
+    charm_rev = 19
     display_name = 'Ceph RADOS Gateway'
     related = [('ceph:radosgw', 'ceph-radosgw:mon'),
                ('ceph-radosgw:identity-service',

--- a/cloudinstall/charms/cinder.py
+++ b/cloudinstall/charms/cinder.py
@@ -26,7 +26,7 @@ class CharmCinder(CharmBase):
     """ Cinder directives """
 
     charm_name = 'cinder'
-    charm_rev = 31
+    charm_rev = 34
     display_name = 'Cinder'
     related = [('cinder:image-service', 'glance:image-service'),
                ('cinder:storage-backend',

--- a/cloudinstall/charms/cinder_ceph.py
+++ b/cloudinstall/charms/cinder_ceph.py
@@ -25,7 +25,7 @@ class CharmCinderCeph(CharmBase):
     """ Cinder-Ceph directives """
 
     charm_name = 'cinder-ceph'
-    charm_rev = 14
+    charm_rev = 16
     display_name = 'Cinder-Ceph'
     deploy_priority = 5
     subordinate = True

--- a/cloudinstall/charms/compute.py
+++ b/cloudinstall/charms/compute.py
@@ -25,7 +25,7 @@ class CharmNovaCompute(CharmBase):
     """ Openstack Nova Compute directives """
 
     charm_name = 'nova-compute'
-    charm_rev = 33
+    charm_rev = 36
     display_name = 'Compute'
     display_priority = DisplayPriorities.Compute
     related = [('nova-compute:neutron-plugin',

--- a/cloudinstall/charms/controller.py
+++ b/cloudinstall/charms/controller.py
@@ -27,7 +27,7 @@ class CharmNovaCloudController(CharmBase):
     """ Openstack Nova Cloud Controller directives """
 
     charm_name = 'nova-cloud-controller'
-    charm_rev = 64
+    charm_rev = 66
     display_name = 'Controller'
     deploy_priority = 2
     related = [('nova-cloud-controller:shared-db',

--- a/cloudinstall/charms/glance.py
+++ b/cloudinstall/charms/glance.py
@@ -21,7 +21,7 @@ class CharmGlance(CharmBase):
     """ Openstack Glance directives """
 
     charm_name = 'glance'
-    charm_rev = 28
+    charm_rev = 30
     display_name = 'Glance'
     related = [('mysql:shared-db', 'glance:shared-db'),
                ('keystone:identity-service', 'glance:identity-service'),

--- a/cloudinstall/charms/glance_simplestreams_sync.py
+++ b/cloudinstall/charms/glance_simplestreams_sync.py
@@ -25,7 +25,7 @@ class CharmGlanceSimplestreamsSync(CharmBase):
     """ Charm directives for glance-simplestreams-sync  """
 
     charm_name = 'glance-simplestreams-sync'
-    charm_rev = 7
+    charm_rev = 8
     display_name = 'Glance - Simplestreams Image Sync'
     display_priority = DisplayPriorities.Other
     related = [('keystone:identity-service',

--- a/cloudinstall/charms/heat.py
+++ b/cloudinstall/charms/heat.py
@@ -22,7 +22,7 @@ class CharmHeat(CharmBase):
     """ Openstack Heat directives """
 
     charm_name = 'heat'
-    charm_rev = 12
+    charm_rev = 14
     display_name = 'Heat'
     related = [('keystone:identity-service',
                 'heat:identity-service'),

--- a/cloudinstall/charms/horizon.py
+++ b/cloudinstall/charms/horizon.py
@@ -21,7 +21,7 @@ class CharmHorizon(CharmBase):
     """ Openstack Horizon directives """
 
     charm_name = 'openstack-dashboard'
-    charm_rev = 19
+    charm_rev = 21
     display_name = 'Openstack Dashboard'
     related = [('keystone:identity-service',
                 'openstack-dashboard:identity-service')]

--- a/cloudinstall/charms/jujugui.py
+++ b/cloudinstall/charms/jujugui.py
@@ -20,7 +20,7 @@ class CharmJujuGui(CharmBase):
     """ Juju gui directives """
 
     charm_name = 'juju-gui'
-    charm_rev = 41
+    charm_rev = 45
     display_name = 'Juju GUI'
     display_priority = DisplayPriorities.Other
     deploy_priority = 1

--- a/cloudinstall/charms/keystone.py
+++ b/cloudinstall/charms/keystone.py
@@ -26,7 +26,7 @@ class CharmKeystone(CharmBase):
     """ Openstack Keystone directives """
 
     charm_name = 'keystone'
-    charm_rev = 31
+    charm_rev = 33
     display_name = 'Keystone'
     related = [('mysql:shared-db', 'keystone:shared-db')]
     deploy_priority = 1

--- a/cloudinstall/charms/mongodb.py
+++ b/cloudinstall/charms/mongodb.py
@@ -22,7 +22,7 @@ class CharmMongo(CharmBase):
     """ MongoDB directives """
 
     charm_name = 'mongodb'
-    charm_rev = 28
+    charm_rev = 33
     display_name = 'MongoDB'
     deploy_priority = 0
     contrib = True

--- a/cloudinstall/charms/mysql.py
+++ b/cloudinstall/charms/mysql.py
@@ -21,7 +21,7 @@ class CharmMysql(CharmBase):
     """ MYSQL directives """
 
     charm_name = 'mysql'
-    charm_rev = 30
+    charm_rev = 33
     display_name = 'MySQL'
     deploy_priority = 0
     is_core = True

--- a/cloudinstall/charms/neutron.py
+++ b/cloudinstall/charms/neutron.py
@@ -27,7 +27,7 @@ class CharmNeutron(CharmBase):
     """ neutron directives """
 
     charm_name = 'neutron-gateway'
-    charm_rev = 7
+    charm_rev = 9
     display_name = 'Neutron'
     deploy_priority = 99
     related = [('mysql:shared-db', 'neutron-gateway:shared-db'),

--- a/cloudinstall/charms/neutron_api.py
+++ b/cloudinstall/charms/neutron_api.py
@@ -23,7 +23,7 @@ log = logging.getLogger('cloudinstall.charms.neutron_api')
 class CharmNeutronAPI(CharmBase):
 
     charm_name = 'neutron-api'
-    charm_rev = 21
+    charm_rev = 23
     display_name = 'Neutron API'
     openstack_release_min = 'j'
     related = [('neutron-api:identity-service',

--- a/cloudinstall/charms/neutron_openvswitch.py
+++ b/cloudinstall/charms/neutron_openvswitch.py
@@ -23,7 +23,7 @@ log = logging.getLogger('cloudinstall.charms.neutron_openvswitch')
 class CharmNeutronOpenvswitch(CharmBase):
 
     charm_name = 'neutron-openvswitch'
-    charm_rev = 13
+    charm_rev = 15
     display_name = 'Neutron OpenVSwitch'
     subordinate = True
     openstack_release_min = 'j'

--- a/cloudinstall/charms/rabbitmq.py
+++ b/cloudinstall/charms/rabbitmq.py
@@ -21,7 +21,7 @@ class CharmRabbitMQ(CharmBase):
     """ RabbitMQ directives """
 
     charm_name = 'rabbitmq-server'
-    charm_rev = 42
+    charm_rev = 43
     display_name = 'RabbitMQ Server'
     deploy_priority = 1
     related = [('rabbitmq-server:amqp',

--- a/cloudinstall/charms/swift.py
+++ b/cloudinstall/charms/swift.py
@@ -25,7 +25,7 @@ class CharmSwift(CharmBase):
     """ swift directives """
 
     charm_name = 'swift-storage'
-    charm_rev = 23
+    charm_rev = 25
     display_name = 'Swift'
     display_priority = DisplayPriorities.Storage
     related = [('swift-proxy:swift-storage', 'swift-storage:swift-storage')]

--- a/cloudinstall/charms/swift_proxy.py
+++ b/cloudinstall/charms/swift_proxy.py
@@ -21,7 +21,7 @@ class CharmSwiftProxy(CharmBase):
     """ swift directives """
 
     charm_name = 'swift-proxy'
-    charm_rev = 25
+    charm_rev = 27
     display_name = 'Swift Proxy'
     display_priority = DisplayPriorities.Storage
     related = [


### PR DESCRIPTION
Mainly affects openstack charms, for whom charmhelpers breaks with new
openstack packages from today, unless updated.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubuntu-solutions-engineering/openstack-installer/842)
<!-- Reviewable:end -->
